### PR TITLE
fix(api): address Code-Reviewer blockers from PR #2

### DIFF
--- a/src/app/api/chat/route.test.ts
+++ b/src/app/api/chat/route.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { POST } from './route'
+
+// Mock Clerk auth
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn(),
+}))
+
+// Mock Prisma
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
+    project: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    conversation: {
+      create: vi.fn(),
+    },
+    message: {
+      create: vi.fn(),
+    },
+  },
+}))
+
+// Mock Claude streaming
+vi.mock('@/lib/ai/claude', () => ({
+  streamChat: vi.fn(),
+}))
+
+import { auth } from '@clerk/nextjs/server'
+import { prisma } from '@/lib/db/prisma'
+import { streamChat } from '@/lib/ai/claude'
+
+const mockAuth = vi.mocked(auth)
+const mockPrisma = vi.mocked(prisma)
+const mockStreamChat = vi.mocked(streamChat)
+
+function createRequest(body: object): Request {
+  return new Request('http://localhost/api/chat', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('POST /api/chat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Authentication', () => {
+    it('should return 401 when not authenticated', async () => {
+      mockAuth.mockResolvedValue({ userId: null } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+
+      const request = createRequest({
+        projectId: 'proj-1',
+        message: 'Hello',
+        phase: 'discovery',
+      })
+
+      const response = await POST(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(401)
+      expect(data.error).toBe('UNAUTHORIZED')
+    })
+
+    it('should return 404 when user not found in database', async () => {
+      mockAuth.mockResolvedValue({ userId: 'user_123' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+      mockPrisma.user.findUnique.mockResolvedValue(null)
+
+      const request = createRequest({
+        projectId: 'proj-1',
+        message: 'Hello',
+        phase: 'discovery',
+      })
+
+      const response = await POST(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(404)
+      expect(data.error).toBe('USER_NOT_FOUND')
+    })
+  })
+
+  describe('Validation', () => {
+    it('should return 400 for empty message', async () => {
+      mockAuth.mockResolvedValue({ userId: 'user_123' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+
+      const request = createRequest({
+        projectId: 'proj-1',
+        message: '',
+        phase: 'discovery',
+      })
+
+      const response = await POST(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('VALIDATION_ERROR')
+    })
+
+    it('should return 400 for invalid phase', async () => {
+      mockAuth.mockResolvedValue({ userId: 'user_123' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+
+      const request = createRequest({
+        projectId: 'proj-1',
+        message: 'Hello',
+        phase: 'invalid-phase',
+      })
+
+      const response = await POST(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('VALIDATION_ERROR')
+    })
+
+    it('should return 400 for missing projectId', async () => {
+      mockAuth.mockResolvedValue({ userId: 'user_123' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+
+      const request = createRequest({
+        message: 'Hello',
+        phase: 'discovery',
+      })
+
+      const response = await POST(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  describe('Project ownership', () => {
+    it('should return 404 when project not found', async () => {
+      mockAuth.mockResolvedValue({ userId: 'user_123' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 'db-user-1',
+        clerkId: 'user_123',
+        email: 'test@example.com',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      mockPrisma.project.findUnique.mockResolvedValue(null)
+
+      const request = createRequest({
+        projectId: 'nonexistent-proj',
+        message: 'Hello',
+        phase: 'discovery',
+      })
+
+      const response = await POST(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(404)
+      expect(data.error).toBe('PROJECT_NOT_FOUND')
+    })
+
+    it('should return 404 when user does not own project', async () => {
+      mockAuth.mockResolvedValue({ userId: 'user_123' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 'db-user-1',
+        clerkId: 'user_123',
+        email: 'test@example.com',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      mockPrisma.project.findUnique.mockResolvedValue({
+        id: 'proj-1',
+        name: 'Other User Project',
+        userId: 'db-user-OTHER', // Different user
+        status: 'IDEATION',
+        productionUrl: null,
+        businessPlan: null,
+        githubRepo: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        conversations: [],
+      } as unknown as Awaited<ReturnType<typeof prisma.project.findUnique>>)
+
+      const request = createRequest({
+        projectId: 'proj-1',
+        message: 'Hello',
+        phase: 'discovery',
+      })
+
+      const response = await POST(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(404)
+      expect(data.error).toBe('PROJECT_NOT_FOUND')
+    })
+  })
+
+  describe('Streaming response', () => {
+    it('should return SSE stream for valid request', async () => {
+      mockAuth.mockResolvedValue({ userId: 'user_123' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 'db-user-1',
+        clerkId: 'user_123',
+        email: 'test@example.com',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      mockPrisma.project.findUnique.mockResolvedValue({
+        id: 'proj-1',
+        name: 'My Project',
+        userId: 'db-user-1',
+        status: 'IDEATION',
+        productionUrl: null,
+        businessPlan: null,
+        githubRepo: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        conversations: [],
+      } as unknown as Awaited<ReturnType<typeof prisma.project.findUnique>>)
+      mockPrisma.conversation.create.mockResolvedValue({
+        id: 'conv-1',
+        projectId: 'proj-1',
+        phase: 'DISCOVERY',
+        status: 'ACTIVE',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        messages: [],
+      } as unknown as Awaited<ReturnType<typeof prisma.conversation.create>>)
+      mockPrisma.message.create.mockResolvedValue({
+        id: 'msg-1',
+        conversationId: 'conv-1',
+        role: 'USER',
+        content: 'Hello',
+        createdAt: new Date(),
+      })
+
+      // Mock streaming response
+      async function* mockStream() {
+        yield 'Hello, '
+        yield 'how can I help?'
+      }
+      mockStreamChat.mockReturnValue(mockStream())
+
+      const request = createRequest({
+        projectId: 'proj-1',
+        message: 'Hello',
+        phase: 'discovery',
+      })
+
+      const response = await POST(request)
+
+      expect(response.headers.get('Content-Type')).toBe('text/event-stream')
+      expect(response.headers.get('Cache-Control')).toBe('no-cache')
+
+      // Read the stream
+      const reader = response.body?.getReader()
+      const chunks: string[] = []
+
+      if (reader) {
+        const decoder = new TextDecoder()
+        let done = false
+        while (!done) {
+          const result = await reader.read()
+          done = result.done
+          if (result.value) {
+            chunks.push(decoder.decode(result.value))
+          }
+        }
+      }
+
+      const fullOutput = chunks.join('')
+      expect(fullOutput).toContain('event: text')
+      expect(fullOutput).toContain('Hello, ')
+      expect(fullOutput).toContain('event: done')
+    })
+  })
+})

--- a/src/app/api/projects/route.test.ts
+++ b/src/app/api/projects/route.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GET, POST } from './route'
+
+// Mock Clerk auth
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn(),
+  clerkClient: vi.fn(),
+}))
+
+// Mock Prisma
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
+    project: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}))
+
+import { auth, clerkClient } from '@clerk/nextjs/server'
+import { prisma } from '@/lib/db/prisma'
+
+const mockAuth = vi.mocked(auth)
+const mockClerkClient = vi.mocked(clerkClient)
+const mockPrisma = vi.mocked(prisma)
+
+describe('GET /api/projects', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    mockAuth.mockResolvedValue({ userId: null } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+
+    const response = await GET()
+    const data = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(data.error).toBe('UNAUTHORIZED')
+  })
+
+  it('should return 404 when user not found', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user_123' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    mockPrisma.user.findUnique.mockResolvedValue(null)
+
+    const response = await GET()
+    const data = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(data.error).toBe('USER_NOT_FOUND')
+  })
+
+  it('should return projects for authenticated user', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user_123' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: 'db-user-1',
+      clerkId: 'user_123',
+      email: 'test@example.com',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    mockPrisma.project.findMany.mockResolvedValue([
+      {
+        id: 'proj-1',
+        name: 'Test Project',
+        status: 'IDEATION',
+        productionUrl: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ] as unknown as Awaited<ReturnType<typeof prisma.project.findMany>>)
+
+    const response = await GET()
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.projects).toHaveLength(1)
+    expect(data.projects[0].name).toBe('Test Project')
+    expect(data.total).toBe(1)
+  })
+})
+
+describe('POST /api/projects', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    mockAuth.mockResolvedValue({ userId: null } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+
+    const request = new Request('http://localhost/api/projects', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'New Project' }),
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(data.error).toBe('UNAUTHORIZED')
+  })
+
+  it('should return 400 for invalid request body', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user_123' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+
+    const request = new Request('http://localhost/api/projects', {
+      method: 'POST',
+      body: JSON.stringify({ name: '' }), // Empty name should fail validation
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('VALIDATION_ERROR')
+  })
+
+  it('should create project for existing user', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user_123' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: 'db-user-1',
+      clerkId: 'user_123',
+      email: 'test@example.com',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    mockPrisma.project.create.mockResolvedValue({
+      id: 'proj-new',
+      name: 'New Project',
+      status: 'IDEATION',
+      userId: 'db-user-1',
+      productionUrl: null,
+      businessPlan: null,
+      githubRepo: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    const request = new Request('http://localhost/api/projects', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'New Project' }),
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(201)
+    expect(data.name).toBe('New Project')
+    expect(data.status).toBe('IDEATION')
+  })
+
+  it('should create user and project for new user', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user_new' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    mockPrisma.user.findUnique.mockResolvedValue(null)
+
+    // Mock Clerk client
+    const mockClerkClientInstance = {
+      users: {
+        getUser: vi.fn().mockResolvedValue({
+          emailAddresses: [{ emailAddress: 'new@example.com' }],
+        }),
+      },
+    }
+    mockClerkClient.mockResolvedValue(mockClerkClientInstance as unknown as Awaited<ReturnType<typeof clerkClient>>)
+
+    mockPrisma.user.create.mockResolvedValue({
+      id: 'db-user-new',
+      clerkId: 'user_new',
+      email: 'new@example.com',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    mockPrisma.project.create.mockResolvedValue({
+      id: 'proj-new',
+      name: 'First Project',
+      status: 'IDEATION',
+      userId: 'db-user-new',
+      productionUrl: null,
+      businessPlan: null,
+      githubRepo: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    const request = new Request('http://localhost/api/projects', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'First Project' }),
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(201)
+    expect(data.name).toBe('First Project')
+    expect(mockPrisma.user.create).toHaveBeenCalledWith({
+      data: {
+        clerkId: 'user_new',
+        email: 'new@example.com',
+      },
+    })
+  })
+
+  it('should return 400 when user has no email in Clerk', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user_no_email' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    mockPrisma.user.findUnique.mockResolvedValue(null)
+
+    const mockClerkClientInstance = {
+      users: {
+        getUser: vi.fn().mockResolvedValue({
+          emailAddresses: [],
+        }),
+      },
+    }
+    mockClerkClient.mockResolvedValue(mockClerkClientInstance as unknown as Awaited<ReturnType<typeof clerkClient>>)
+
+    const request = new Request('http://localhost/api/projects', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Project' }),
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('USER_EMAIL_NOT_FOUND')
+  })
+})

--- a/src/lib/ai/parsers.test.ts
+++ b/src/lib/ai/parsers.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest'
+import { extractJSON, isPlanReady, extractBusinessPlan } from './parsers'
+
+describe('extractJSON', () => {
+  it('should extract JSON from markdown code block', () => {
+    const response = `Here is the plan:
+
+\`\`\`json
+{"name": "Test App", "description": "A test application"}
+\`\`\`
+
+Let me know if you want changes.`
+
+    const result = extractJSON<{ name: string; description: string }>(response)
+    expect(result).toEqual({
+      name: 'Test App',
+      description: 'A test application',
+    })
+  })
+
+  it('should extract direct JSON without code block', () => {
+    const response = `The result is {"status": "success", "count": 42}`
+
+    const result = extractJSON<{ status: string; count: number }>(response)
+    expect(result).toEqual({ status: 'success', count: 42 })
+  })
+
+  it('should return null for invalid JSON', () => {
+    const response = `\`\`\`json
+{invalid json here}
+\`\`\``
+
+    const result = extractJSON(response)
+    expect(result).toBeNull()
+  })
+
+  it('should return null when no JSON found', () => {
+    const response = 'This is just plain text without any JSON'
+
+    const result = extractJSON(response)
+    expect(result).toBeNull()
+  })
+
+  it('should handle nested JSON objects', () => {
+    const response = `\`\`\`json
+{
+  "user": {
+    "name": "John",
+    "settings": {
+      "theme": "dark"
+    }
+  }
+}
+\`\`\``
+
+    const result = extractJSON<{
+      user: { name: string; settings: { theme: string } }
+    }>(response)
+    expect(result).toEqual({
+      user: {
+        name: 'John',
+        settings: { theme: 'dark' },
+      },
+    })
+  })
+})
+
+describe('isPlanReady', () => {
+  it('should return true when response has json block with coreFeatures', () => {
+    const response = `Here is your plan:
+
+\`\`\`json
+{
+  "name": "My App",
+  "coreFeatures": [{"id": "1", "name": "Login"}]
+}
+\`\`\``
+
+    expect(isPlanReady(response)).toBe(true)
+  })
+
+  it('should return true when response has json block with architecture', () => {
+    const response = `\`\`\`json
+{
+  "name": "My App",
+  "architecture": {"frontend": "React"}
+}
+\`\`\``
+
+    expect(isPlanReady(response)).toBe(true)
+  })
+
+  it('should return false when no json block', () => {
+    const response = 'The coreFeatures are important but no JSON here'
+
+    expect(isPlanReady(response)).toBe(false)
+  })
+
+  it('should return false when json block without required fields', () => {
+    const response = `\`\`\`json
+{"name": "App", "description": "Test"}
+\`\`\``
+
+    expect(isPlanReady(response)).toBe(false)
+  })
+})
+
+describe('extractBusinessPlan', () => {
+  it('should extract a valid business plan', () => {
+    const response = `\`\`\`json
+{
+  "name": "TaskManager",
+  "tagline": "Manage tasks easily",
+  "description": "A task management app",
+  "problemStatement": "People struggle with task organization",
+  "targetAudience": {
+    "primary": "Small teams",
+    "painPoints": ["Disorganization", "Missed deadlines"]
+  },
+  "coreFeatures": [
+    {
+      "id": "f1",
+      "name": "Task Creation",
+      "description": "Create and assign tasks",
+      "priority": "must-have",
+      "complexity": "low"
+    }
+  ],
+  "niceToHaveFeatures": [],
+  "successMetrics": [
+    {"name": "DAU", "target": "1000", "timeframe": "3 months"}
+  ]
+}
+\`\`\``
+
+    const result = extractBusinessPlan(response)
+    expect(result).not.toBeNull()
+    expect(result?.name).toBe('TaskManager')
+    expect(result?.coreFeatures).toHaveLength(1)
+    expect(result?.coreFeatures[0].name).toBe('Task Creation')
+  })
+
+  it('should return null for invalid business plan', () => {
+    const response = 'No JSON here'
+
+    const result = extractBusinessPlan(response)
+    expect(result).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Fix email placeholder: fetch real email from Clerk API
- Add 27 new tests for critical functionality
- All 31 tests passing

## Blockers addressed
From Code-Reviewer on PR #2:
- [x] Email placeholder - usuarios podem ficar com email invalido
- [x] Sem testes - features criticas sem cobertura

## Changes
- `src/app/api/projects/route.ts` - Use Clerk API to get real email
- `src/lib/ai/parsers.test.ts` - 11 tests for JSON parsing
- `src/app/api/projects/route.test.ts` - 8 tests for projects API
- `src/app/api/chat/route.test.ts` - 8 tests for chat API

## Test plan
- [x] `npm test` passes (31 tests)
- [x] `npm run lint` passes
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)