### PR TITLE
fix(auth): add ClerkGuard to prevent runtime error

### DIFF
--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,9 +1,12 @@
 import { SignIn } from '@clerk/nextjs'
+import { ClerkGuard } from '@/components/clerk-guard'
 
 export default function SignInPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <SignIn />
-    </div>
+    <ClerkGuard>
+      <div className="flex min-h-screen items-center justify-center">
+        <SignIn />
+      </div>
+    </ClerkGuard>
   )
 }

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,9 +1,12 @@
 import { SignUp } from '@clerk/nextjs'
+import { ClerkGuard } from '@/components/clerk-guard'
 
 export default function SignUpPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <SignUp />
-    </div>
+    <ClerkGuard>
+      <div className="flex min-h-screen items-center justify-center">
+        <SignUp />
+      </div>
+    </ClerkGuard>
   )
 }

--- a/src/components/clerk-guard.tsx
+++ b/src/components/clerk-guard.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+interface ClerkGuardProps {
+  children: React.ReactNode
+  fallback?: React.ReactNode
+}
+
+export function ClerkGuard({ children, fallback }: ClerkGuardProps) {
+  const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+
+  if (!publishableKey || publishableKey.startsWith('pk_test_dummy')) {
+    return (
+      fallback ?? (
+        <div className="flex min-h-screen items-center justify-center p-4">
+          <div className="max-w-md space-y-4 text-center">
+            <h1 className="text-2xl font-bold">Clerk Not Configured</h1>
+            <p className="text-muted-foreground">
+              Authentication is not configured. Please add your Clerk keys to
+              <code className="mx-1 rounded bg-muted px-1 py-0.5">
+                .env.local
+              </code>
+            </p>
+            <div className="rounded-lg bg-muted p-4 text-left text-sm">
+              <pre className="whitespace-pre-wrap">
+                {`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...
+CLERK_SECRET_KEY=sk_test_...`}
+              </pre>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Get your keys at{' '}
+              <a
+                href="https://dashboard.clerk.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary underline"
+              >
+                dashboard.clerk.com
+              </a>
+            </p>
+          </div>
+        </div>
+      )
+    )
+  }
+
+  return <>{children}</>
+}


### PR DESCRIPTION
## Summary
- Adiciona componente `ClerkGuard` que detecta se Clerk esta configurado
- Exibe mensagem util com instrucoes quando Clerk nao esta configurado
- Previne erro de runtime "useSession can only be used within ClerkProvider"

## Problema
Quando as chaves do Clerk nao estao configuradas no `.env.local`, clicar em "Sign In" ou "Get Started" causava erro de runtime.

## Solucao
O componente `ClerkGuard` verifica se `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` esta configurada e:
- Se sim: renderiza os componentes Clerk normalmente
- Se nao: mostra uma pagina com instrucoes de como configurar

## Teste
1. Remover/comentar as chaves do Clerk no `.env.local`
2. Acessar `/sign-up` ou `/sign-in`
3. Deve exibir mensagem amigavel ao inves de erro

Generated with [Claude Code](https://claude.com/claude-code)