### PR TITLE
feat(ci): add Husky pre-push hooks for lint and tests

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Pre-commit: verificação rápida (lint apenas)
+echo "🔍 Running lint..."
+npm run lint || exit 1
+echo "✅ Lint passed!"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Pre-push: verificação antes de enviar ao remote
+# Lint e tests devem passar. Build roda no CI.
+
+echo "🚀 Running pre-push checks..."
+echo ""
+
+# 1. Lint
+echo "📝 [1/2] Running lint..."
+npm run lint || {
+  echo "❌ Lint failed! Fix errors before pushing."
+  exit 1
+}
+echo "✅ Lint passed!"
+echo ""
+
+# 2. Tests
+echo "🧪 [2/2] Running tests..."
+npm test || {
+  echo "❌ Tests failed! Fix tests before pushing."
+  exit 1
+}
+echo "✅ Tests passed!"
+echo ""
+
+echo "🎉 All checks passed! Pushing..."
+# Note: npm run build runs in CI (GitHub Actions), not locally

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.0",
         "@testing-library/react": "^16.1.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^22.10.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -36,6 +37,7 @@
         "autoprefixer": "^10.4.0",
         "eslint": "^9.17.0",
         "eslint-config-next": "^15.1.0",
+        "husky": "^9.1.7",
         "jsdom": "^25.0.0",
         "postcss": "^8.4.0",
         "prisma": "^6.2.0",
@@ -2730,6 +2732,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -5993,6 +6009,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
-    "db:studio": "prisma studio"
+    "db:studio": "prisma studio",
+    "prepare": "husky"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",
@@ -37,6 +38,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.0",
     "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22.10.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
@@ -44,6 +46,7 @@
     "autoprefixer": "^10.4.0",
     "eslint": "^9.17.0",
     "eslint-config-next": "^15.1.0",
+    "husky": "^9.1.7",
     "jsdom": "^25.0.0",
     "postcss": "^8.4.0",
     "prisma": "^6.2.0",

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,5 @@
 import '@testing-library/jest-dom/vitest'
+import { vi } from 'vitest'
+
+// Mock scrollIntoView (not available in jsdom)
+Element.prototype.scrollIntoView = vi.fn()


### PR DESCRIPTION
## Summary
- Configure Husky pre-commit (lint) and pre-push (lint+test) hooks
- Build runs in CI only (per TBD best practices - fast feedback locally)

## Changes
- `.husky/pre-commit` - Lint only (fast)
- `.husky/pre-push` - Lint + Test (no build)
- `src/test/setup.ts` - Add scrollIntoView mock for jsdom

## Test plan
- [x] Pre-commit hook runs lint
- [x] Pre-push hook runs lint + tests
- [x] All 146 tests passing

**Part 2 of 3** - BDD Workflow Implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)