### PR TITLE
feat(planning): implement Business Plan edit mode and approval state

### DIFF
--- a/tests/e2e/steps/planning.steps.tsx
+++ b/tests/e2e/steps/planning.steps.tsx
@@ -135,7 +135,9 @@ describe('Planning: Business Plan - Visualização', () => {
       />
     )
 
-    expect(screen.getByText(/Aguardando geração do plano/)).toBeInTheDocument()
+    // Pode haver múltiplas mensagens (business plan + technical plan)
+    const messages = screen.getAllByText(/Aguardando geração do plano/)
+    expect(messages.length).toBeGreaterThanOrEqual(1)
   })
 })
 


### PR DESCRIPTION
## Summary
- Add edit mode for Business Plan with editable tagline
- Add "Aprovado" badge when plan is approved
- Add action buttons: "Editar Plano", "Salvar Alterações", "Cancelar"
- Hide buttons when plan is approved (readonly state)

## TDD Workflow
1. RED: Added failing tests based on Gherkin spec (planning.feature)
2. GREEN: Implemented features to make tests pass
3. All 163 tests passing

## Tests Added (7 tests)
- Exibe as seções do Business Plan
- Exibe botões "Editar Plano" e "Aprovar e Continuar"
- Exibe mensagem de aguardando quando não há plano
- Entra em modo de edição ao clicar em "Editar Plano"
- Cancela edição e volta para visualização
- Chama onApprove ao clicar em "Aprovar e Continuar"
- Exibe badge "Aprovado" e esconde botões quando aprovado

## Test plan
- [x] `npm test` - 163 tests passing
- [x] `npm run lint` - No errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)