### PR TITLE
fix(discovery): sync question progress and render markdown

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -76,11 +76,16 @@ export async function POST(request: Request) {
     })
 
     // Update question progress for discovery phase
-    // When user sends a message, mark current question as completed and advance
+    // The first user message answers Q0 ("O que criar?") which is built into the UI,
+    // not one of the 5 tracked questions. Only advance after the AI has asked Q1+.
     let currentQuestion = conversation.currentQuestion
     const completedQuestions = [...conversation.completedQuestions]
+    // Uses the in-memory snapshot from the Prisma query above — excludes the
+    // message.create on line 70, so length === 0 means this is the first message.
+    const existingUserMessages = conversation.messages.filter((m) => m.role === 'USER')
+    const isFirstMessage = existingUserMessages.length === 0
 
-    if (phase === 'discovery' && currentQuestion <= 5) {
+    if (phase === 'discovery' && !isFirstMessage && currentQuestion <= 5) {
       // Mark current question as completed (if not already)
       if (!completedQuestions.includes(currentQuestion)) {
         completedQuestions.push(currentQuestion)

--- a/src/components/project/ChatPanel.tsx
+++ b/src/components/project/ChatPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 import { useProjectLayout } from './ProjectLayout'
 import { FEATURES } from '@/config/features'
 import { QUICK_REPLIES_BY_QUESTION } from '@/types'
@@ -9,6 +9,18 @@ interface Message {
   id: string
   role: 'user' | 'assistant'
   content: string
+}
+
+// Render **bold** spans in assistant messages
+function renderBoldSpans(text: string): React.ReactNode[] {
+  const parts = text.split(/(\*\*[^*]+\*\*)/g)
+  return parts.map((part, i) => {
+    const boldMatch = part.match(/^\*\*(.+)\*\*$/)
+    if (boldMatch) {
+      return <strong key={i}>{boldMatch[1]}</strong>
+    }
+    return <React.Fragment key={i}>{part}</React.Fragment>
+  })
 }
 
 // Remove JSON from message for display
@@ -333,11 +345,11 @@ export function ChatPanel({
                         : 'text-gray-700'
                     }`}
                   >
-                    <p className="whitespace-pre-wrap">
+                    <div className="whitespace-pre-wrap">
                       {message.role === 'assistant'
-                        ? stripJsonFromDisplay(message.content)
+                        ? renderBoldSpans(stripJsonFromDisplay(message.content))
                         : message.content}
-                    </p>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

- **Off-by-one fix:** First user message answers Q0 (the built-in "O que criar?" prompt), not Q1. `currentQuestion` was advancing on every message including Q0, causing quick replies to display one question ahead of the AI. Now skips the advance when the conversation has zero prior user messages.
- **Markdown rendering:** Assistant messages with `**bold**` syntax were displayed as literal asterisks. Added a lightweight inline markdown renderer for bold spans in `ChatPanel`.
- **Regression tests:** Two new tests verify that the first message does not trigger an advance, and the second message correctly advances and emits `question_progress`.

## Test plan

- [x] `conversation.update` is NOT called on the first user message
- [x] `conversation.update` IS called on the second user message with correct `currentQuestion` and `completedQuestions`
- [x] `question_progress` SSE event emitted with correct `current` value
- [ ] Manual: open discovery, send first message — progress stays "Pergunta 1 de 5", quick replies match Q1
- [ ] Manual: answer Q1 — progress advances to "Pergunta 2 de 5", quick replies match Q2
- [ ] Manual: bold text in AI responses renders as bold (not literal `**`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)