### PR TITLE
feat(connection): add checkpoint flow before GitHub OAuth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,9 @@ Se o Gherkin diz que o botao mostra `📱 App de gestão`, deve existir um teste
 **Regra 5 — Uma tarefa por vez.**
 Nao abrir PR B enquanto PR A nao esta mergado, a menos que sejam verdadeiramente independentes. Isso reduz branches ativos e evita merge conflicts e confusao de contexto.
 
+**Regra 6 — Todo texto visível ao utilizador deve estar em português brasileiro com acentuação correta.**
+Nunca gerar texto em português sem acentos (ex: "Nao" em vez de "Não", "voce" em vez de "você"). Isso inclui: conteúdo HTML, strings de UI, mensagens de chat, labels, placeholders, títulos e botões. Nomes de arquivos, classes CSS, variáveis JS e URLs podem permanecer sem acentos (ASCII-safe).
+
 ## Fluxo de PR (OBRIGATORIO)
 
 1. Criar branch e fazer commits

--- a/docs/specifications/connection.feature
+++ b/docs/specifications/connection.feature
@@ -13,20 +13,43 @@ Funcionalidade: Fase de Conexão (GitHub + Vercel)
     E o projeto está no status "CONNECTING"
 
   # ==========================================================================
-  # SUB-ESTADO: github — OAuth não realizado
+  # SUB-ESTADO: github — Checkpoint (triagem pré-OAuth)
   # githubRepoUrl === null
   # ==========================================================================
 
-  @github @oauth @visualizacao
-  Cenário: Visualizar tela de conexão GitHub (estado inicial)
+  @github @checkpoint @visualizacao
+  Cenário: Exibir checkpoint "Você já tem GitHub?" (estado inicial)
     Dado que o projeto não tem githubRepoUrl
     Quando eu acesso a página do projeto
-    Então o workspace exibe a tela "Conectar com GitHub"
-    E vejo o icone do GitHub grande no centro
-    E vejo texto explicativo sobre as permissões necessárias
-    E vejo a lista de permissões: repositórios, usuário, email
+    Então o workspace exibe o checkpoint "Hora de guardar seu código"
+    E vejo texto "Você já tem uma conta no GitHub?"
+    E vejo botão "Sim, já tenho" com ícone GitHub
+    E vejo botão "Ainda não tenho" com ícone de criação
+    E vejo detalhes expansíveis "O que é GitHub?"
+
+  @github @checkpoint @caminho-sim
+  Cenário: Clicar "Sim, já tenho" avança para OAuth
+    Dado que estou no checkpoint de GitHub
+    Quando clico em "Sim, já tenho"
+    Então o workspace exibe a tela de OAuth "Conectar com GitHub"
+    E vejo a lista de permissões simplificada
     E vejo o botão "Conectar com GitHub"
-    E vejo o tip box com dica sobre OAuth
+
+  @github @checkpoint @caminho-nao
+  Cenário: Clicar "Ainda não tenho" mostra tutorial
+    Dado que estou no checkpoint de GitHub
+    Quando clico em "Ainda não tenho"
+    Então o workspace exibe a tela "Criar sua conta no GitHub"
+    E vejo 3 passos numerados para criar conta
+    E vejo o botão "Abrir GitHub (nova aba)"
+    E vejo o botão "Já criei minha conta, continuar"
+    E vejo dica sobre o plano gratuito
+
+  @github @checkpoint @tutorial-continuar
+  Cenário: Após criar conta, avançar para OAuth
+    Dado que estou na tela "Criar sua conta no GitHub"
+    Quando clico em "Já criei minha conta, continuar"
+    Então o workspace exibe a tela de OAuth "Conectar com GitHub"
 
   @github @oauth @navegacao
   Cenário: Sidebar mostra estado correto na fase Conexão
@@ -37,12 +60,20 @@ Funcionalidade: Fase de Conexão (GitHub + Vercel)
     E vejo "Fase 3/6" no indicador de jornada
 
   # ==========================================================================
-  # SUB-ESTADO: github — Fluxo OAuth
+  # SUB-ESTADO: github — Fluxo OAuth (após checkpoint)
   # ==========================================================================
+
+  @github @oauth @visualizacao
+  Cenário: Visualizar tela de OAuth após checkpoint
+    Dado que passei pelo checkpoint clicando "Sim, já tenho"
+    Então o workspace exibe a tela "Conectar com GitHub"
+    E vejo a lista de permissões: criar repositório, ver perfil, verificar email
+    E vejo o botão "Conectar com GitHub"
+    E vejo nota "Você será redirecionado para github.com e voltará automaticamente."
 
   @github @oauth @fluxo
   Cenário: Iniciar fluxo OAuth do GitHub
-    Dado que estou na tela de conexão GitHub
+    Dado que estou na tela de OAuth "Conectar com GitHub"
     Quando clico em "Conectar com GitHub"
     Então o sistema salva o projectId em cookie "github_oauth_project_id"
     E redireciona para a URL de autorização do GitHub

--- a/mockups/index.html
+++ b/mockups/index.html
@@ -369,6 +369,16 @@
           <div class="hub-card-description">Conectando Vercel e pipeline</div>
           <span class="hub-card-badge success">✓ Concluído</span>
         </a>
+        <a href="project/phase-3-connection/04-opcao1-checkpoint.html" class="hub-card">
+          <div class="hub-card-title">04 - Opção 1: Checkpoint</div>
+          <div class="hub-card-description">UX simples: "Já tem GitHub?" + criar conta + OAuth</div>
+          <span class="hub-card-badge warning">Proposta UX</span>
+        </a>
+        <a href="project/phase-3-connection/05-opcao2-guia-visual.html" class="hub-card">
+          <div class="hub-card-title">05 - Opção 2: Guia Visual</div>
+          <div class="hub-card-description">Stepper 3 etapas + preview OAuth + tutorial + checklist</div>
+          <span class="hub-card-badge warning">Proposta UX</span>
+        </a>
       </div>
     </section>
 
@@ -519,6 +529,46 @@
           <div class="hub-card-description">Estúdio de edição de prompts para geração de planos técnicos</div>
           <span class="hub-card-badge success">✓ Concluído</span>
         </a>
+        <a href="admin/credits/01-admin-credits-control-tower.html" class="hub-card">
+          <div class="hub-card-title">Credits Admin - Proposta 1</div>
+          <div class="hub-card-description">Control Tower com KPI financeiro e pricing por jornada</div>
+          <span class="hub-card-badge warning">Novo</span>
+        </a>
+        <a href="admin/credits/02-admin-credits-pricing-lab.html" class="hub-card">
+          <div class="hub-card-title">Credits Admin - Proposta 2</div>
+          <div class="hub-card-description">Pricing Lab com simulador de margem e politica de trial</div>
+          <span class="hub-card-badge warning">Novo</span>
+        </a>
+        <a href="admin/credits/03-admin-credits-ops-ledger.html" class="hub-card">
+          <div class="hub-card-title">Credits Admin - Proposta 3</div>
+          <div class="hub-card-description">Console operacional com ledger, hold/capture/refund e risco</div>
+          <span class="hub-card-badge warning">Novo</span>
+        </a>
+      </div>
+    </section>
+
+    <!-- Credits User Section -->
+    <section class="hub-section">
+      <h2 class="hub-section-title">
+        <span class="hub-section-title-icon">💳</span>
+        Financeiro - Usuário
+      </h2>
+      <div class="hub-grid">
+        <a href="project/credits/01-user-credits-usage-dock.html" class="hub-card">
+          <div class="hub-card-title">Credits User - Proposta 1</div>
+          <div class="hub-card-description">Dock lateral de consumo em tempo real (estilo Claude)</div>
+          <span class="hub-card-badge warning">Novo</span>
+        </a>
+        <a href="project/credits/02-user-credits-wallet-timeline.html" class="hub-card">
+          <div class="hub-card-title">Credits User - Proposta 2</div>
+          <div class="hub-card-description">Wallet com linha do tempo de consumo e forecast de saldo</div>
+          <span class="hub-card-badge warning">Novo</span>
+        </a>
+        <a href="project/credits/03-user-credits-context-bar.html" class="hub-card">
+          <div class="hub-card-title">Credits User - Proposta 3</div>
+          <div class="hub-card-description">Barra contextual persistente com janela de uso e upgrade</div>
+          <span class="hub-card-badge warning">Novo</span>
+        </a>
       </div>
     </section>
 
@@ -526,7 +576,7 @@
     <footer class="hub-footer">
       <p><span class="status-indicator"></span> Mockups navegáveis | True Coding © 2026</p>
       <p style="margin-top: var(--space-2);">
-        <strong>Status:</strong> ✅ Todos os mockups completos (48 arquivos: 33 telas + 9 componentes + 5 erros + 1 admin) | Desktop + Mobile + Admin + Error States
+        <strong>Status:</strong> ✅ Hub atualizado com propostas de créditos (admin + usuário) | Desktop + Mobile + Admin + Error States
       </p>
     </footer>
   </div>

--- a/mockups/project/phase-3-connection/04-opcao1-checkpoint.html
+++ b/mockups/project/phase-3-connection/04-opcao1-checkpoint.html
@@ -1,0 +1,487 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Conexão GitHub - Checkpoint | True Coding</title>
+  <link rel="stylesheet" href="../../css/tokens.css">
+  <link rel="stylesheet" href="../../css/layout.css">
+  <link rel="stylesheet" href="../../css/components.css">
+  <style>
+    /* Step choice buttons */
+    .choice-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: var(--space-4);
+      margin-top: var(--space-6);
+    }
+    .choice-card {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: var(--space-3);
+      padding: var(--space-6);
+      background: var(--color-bg-primary);
+      border: 2px solid var(--color-border);
+      border-radius: var(--border-radius-lg);
+      cursor: pointer;
+      transition: all var(--transition-fast);
+      text-align: center;
+    }
+    .choice-card:hover {
+      border-color: var(--color-primary);
+      box-shadow: var(--shadow-md);
+      transform: translateY(-2px);
+    }
+    .choice-card-icon {
+      width: 56px;
+      height: 56px;
+      border-radius: var(--border-radius-lg);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .choice-card-icon.github {
+      background: var(--color-gray-900);
+      color: white;
+    }
+    .choice-card-icon.create {
+      background: var(--color-primary-light);
+      color: var(--color-primary);
+    }
+    .choice-card-title {
+      font-size: var(--font-size-lg);
+      font-weight: var(--font-weight-semibold);
+      color: var(--color-text-primary);
+    }
+    .choice-card-desc {
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+      line-height: var(--line-height-relaxed);
+    }
+
+    /* Expandable details */
+    .info-details {
+      margin-top: var(--space-6);
+      border: 1px solid var(--color-border);
+      border-radius: var(--border-radius-md);
+      overflow: hidden;
+    }
+    .info-details summary {
+      padding: var(--space-3) var(--space-4);
+      font-size: var(--font-size-sm);
+      font-weight: var(--font-weight-medium);
+      color: var(--color-text-secondary);
+      cursor: pointer;
+      background: var(--color-bg-secondary);
+      transition: background var(--transition-fast);
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: var(--space-2);
+    }
+    .info-details summary::-webkit-details-marker {
+      display: none;
+    }
+    .info-details summary::before {
+      content: "▸";
+      font-size: 12px;
+      transition: transform var(--transition-fast);
+    }
+    .info-details[open] summary::before {
+      transform: rotate(90deg);
+    }
+    .info-details summary:hover {
+      background: var(--color-bg-tertiary);
+    }
+    .info-details .details-content {
+      padding: var(--space-4);
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+      line-height: var(--line-height-relaxed);
+      border-top: 1px solid var(--color-border);
+    }
+
+    /* Numbered step cards */
+    .step-cards {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-4);
+      margin-top: var(--space-6);
+    }
+    .step-card {
+      display: flex;
+      gap: var(--space-4);
+      align-items: flex-start;
+      padding: var(--space-4);
+      background: var(--color-bg-primary);
+      border: 1px solid var(--color-border);
+      border-radius: var(--border-radius-lg);
+    }
+    .step-number {
+      width: 32px;
+      height: 32px;
+      border-radius: var(--border-radius-full);
+      background: var(--color-primary);
+      color: white;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: var(--font-weight-bold);
+      font-size: var(--font-size-sm);
+      flex-shrink: 0;
+    }
+    .step-card-content {
+      flex: 1;
+    }
+    .step-card-content p {
+      margin: 0;
+      font-size: var(--font-size-sm);
+      color: var(--color-text-primary);
+      line-height: var(--line-height-relaxed);
+    }
+
+    /* Tip box */
+    .tip-box {
+      margin-top: var(--space-6);
+      padding: var(--space-4);
+      background: var(--color-primary-light);
+      border-radius: var(--border-radius-md);
+      border-left: 4px solid var(--color-primary);
+    }
+    .tip-box p {
+      margin: 0;
+      font-size: var(--font-size-sm);
+      color: var(--color-text-primary);
+      line-height: var(--line-height-normal);
+    }
+
+    /* Buttons area */
+    .actions {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-3);
+      margin-top: var(--space-6);
+    }
+    .actions-row {
+      display: flex;
+      gap: var(--space-3);
+    }
+
+    /* Permissions list */
+    .permissions-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    .permissions-list li {
+      display: flex;
+      gap: var(--space-3);
+      padding: var(--space-3) 0;
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+      line-height: var(--line-height-relaxed);
+      border-bottom: 1px solid var(--color-border);
+    }
+    .permissions-list li:last-child {
+      border-bottom: none;
+    }
+    .permissions-list .perm-label {
+      font-weight: var(--font-weight-medium);
+      color: var(--color-text-primary);
+      white-space: nowrap;
+    }
+
+    /* OAuth note */
+    .oauth-note {
+      margin-top: var(--space-4);
+      text-align: center;
+      font-size: var(--font-size-xs);
+      color: var(--color-text-tertiary);
+    }
+    .oauth-footer {
+      margin-top: var(--space-6);
+      text-align: center;
+      font-size: var(--font-size-xs);
+      color: var(--color-text-tertiary);
+      line-height: var(--line-height-relaxed);
+    }
+  </style>
+</head>
+<body>
+  <div class="app-layout">
+    <aside class="sidebar">
+      <div class="sidebar-header">
+        <div class="logo">
+          <div class="logo-icon">TC</div>
+          <span>True Coding</span>
+        </div>
+        <div class="project-name">Meu App Delivery</div>
+        <a href="../../dashboard/list.html" class="back-link">← Dashboard</a>
+        <div class="journey-progress">
+          <div class="journey-progress-header">
+            <span class="journey-label">JORNADA</span>
+            <span class="journey-count">Fase 3/6</span>
+          </div>
+          <div class="journey-dots">
+            <div class="journey-dot completed"></div>
+            <div class="journey-dot completed"></div>
+            <div class="journey-dot current"></div>
+            <div class="journey-dot"></div>
+            <div class="journey-dot"></div>
+            <div class="journey-dot"></div>
+          </div>
+        </div>
+      </div>
+      <nav class="sidebar-nav">
+        <div class="nav-section">
+          <div class="nav-section-title">FASES</div>
+          <div class="nav-item completed"><span class="phase-icon"></span><span>Ideação</span></div>
+          <div class="nav-item completed"><span class="phase-icon"></span><span>Planejamento</span></div>
+          <a href="#" class="nav-item in-progress"><span class="phase-icon"></span><span>Conexão</span></a>
+          <div class="nav-item blocked"><span class="phase-icon"></span><span>Geração</span></div>
+          <div class="nav-item blocked"><span class="phase-icon"></span><span>Deploy</span></div>
+          <div class="nav-item blocked"><span class="phase-icon"></span><span>Online</span></div>
+        </div>
+      </nav>
+      <div class="sidebar-footer">
+        <div class="user-info">
+          <div class="user-avatar">RN</div>
+          <div class="user-details">
+            <div class="user-name">Renato Natali</div>
+            <div class="user-email">renato@email.com</div>
+          </div>
+        </div>
+      </div>
+    </aside>
+
+    <main class="main-content">
+      <section class="workspace">
+
+        <!-- ============================================================
+             STEP 1: Checkpoint — Você já tem GitHub?
+             ============================================================ -->
+        <div class="step" id="step-1">
+          <div class="workspace-header">
+            <div class="workspace-breadcrumb">Conexão › Preparação</div>
+            <h2 class="workspace-title">Hora de guardar seu código</h2>
+            <p class="workspace-subtitle">Precisamos conectar sua conta do GitHub para criar o repositório do projeto <strong>Meu App Delivery</strong>.</p>
+          </div>
+
+          <div style="max-width: 600px; margin: 0 auto;">
+            <p style="font-size: var(--font-size-sm); color: var(--color-text-secondary); line-height: var(--line-height-relaxed); margin-bottom: var(--space-2);">
+              O GitHub é como um cofre digital para o código do seu aplicativo. É lá que seu projeto vai morar.
+            </p>
+
+            <h3 style="font-size: var(--font-size-xl); font-weight: var(--font-weight-semibold); color: var(--color-text-primary); margin-top: var(--space-8);">
+              Você já tem uma conta no GitHub?
+            </h3>
+
+            <div class="choice-grid">
+              <button class="choice-card" onclick="showStep(3)">
+                <div class="choice-card-icon github">
+                  <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
+                  </svg>
+                </div>
+                <div class="choice-card-title">Sim, já tenho</div>
+                <div class="choice-card-desc">Vamos conectar sua conta existente</div>
+              </button>
+
+              <button class="choice-card" onclick="showStep(2)">
+                <div class="choice-card-icon create">
+                  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="10"/>
+                    <line x1="12" y1="8" x2="12" y2="16"/>
+                    <line x1="8" y1="12" x2="16" y2="12"/>
+                  </svg>
+                </div>
+                <div class="choice-card-title">Ainda não tenho</div>
+                <div class="choice-card-desc">Vou te ajudar a criar uma conta</div>
+              </button>
+            </div>
+
+            <details class="info-details">
+              <summary>O que é GitHub?</summary>
+              <div class="details-content">
+                GitHub é a maior plataforma do mundo para armazenar código de forma segura. Empresas como Microsoft, Google e Netflix usam. É gratuito para projetos pessoais.
+              </div>
+            </details>
+          </div>
+        </div>
+
+        <!-- ============================================================
+             STEP 2: Criar Conta GitHub
+             ============================================================ -->
+        <div class="step" id="step-2" style="display: none;">
+          <div class="workspace-header">
+            <div class="workspace-breadcrumb">Conexão › Criar Conta</div>
+            <h2 class="workspace-title">Criar sua conta no GitHub</h2>
+            <p class="workspace-subtitle">É rápido, leva menos de 2 minutos</p>
+          </div>
+
+          <div style="max-width: 600px; margin: 0 auto;">
+            <div class="step-cards">
+              <div class="step-card">
+                <div class="step-number">1</div>
+                <div class="step-card-content">
+                  <p>Acesse github.com e clique em <strong>Sign up</strong></p>
+                </div>
+              </div>
+              <div class="step-card">
+                <div class="step-number">2</div>
+                <div class="step-card-content">
+                  <p>Preencha email, senha e nome de usuário</p>
+                </div>
+              </div>
+              <div class="step-card">
+                <div class="step-number">3</div>
+                <div class="step-card-content">
+                  <p>Confirme seu email e volte aqui</p>
+                </div>
+              </div>
+            </div>
+
+            <div class="actions">
+              <a href="https://github.com/signup" target="_blank" class="btn btn-primary btn-lg" style="width: 100%; justify-content: center;">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+                  <polyline points="15 3 21 3 21 9"/>
+                  <line x1="10" y1="14" x2="21" y2="3"/>
+                </svg>
+                Abrir GitHub (nova aba)
+              </a>
+              <button class="btn btn-secondary btn-lg" onclick="showStep(3)" style="width: 100%; justify-content: center;">
+                Já criei minha conta, continuar
+              </button>
+            </div>
+
+            <div class="tip-box">
+              <p>💡 <strong>Dica:</strong> Escolha o plano <strong>gratuito</strong> (Free). É tudo que você precisa.</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- ============================================================
+             STEP 3: OAuth — Conectar com GitHub
+             ============================================================ -->
+        <div class="step" id="step-3" style="display: none;">
+          <div class="workspace-header">
+            <div class="workspace-breadcrumb">Conexão › GitHub</div>
+            <h2 class="workspace-title">Conectar com GitHub</h2>
+            <p class="workspace-subtitle">Vamos criar o repositório <strong>Meu App Delivery</strong> automaticamente após a conexão.</p>
+          </div>
+
+          <div style="max-width: 600px; margin: 0 auto;">
+            <div class="card">
+              <div class="card-body" style="text-align: center; padding: var(--space-8);">
+                <div style="margin-bottom: var(--space-6);">
+                  <svg width="80" height="80" viewBox="0 0 24 24" fill="currentColor" style="color: var(--color-text-primary);">
+                    <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
+                  </svg>
+                </div>
+
+                <div style="padding: var(--space-4); background: var(--color-bg-secondary); border-radius: var(--border-radius-md); text-align: left; margin-bottom: var(--space-6);">
+                  <div style="font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--color-text-primary); margin-bottom: var(--space-3);">
+                    🔐 Permissões Necessárias:
+                  </div>
+                  <ul class="permissions-list">
+                    <li>
+                      <span class="perm-label">Criar repositório</span>
+                      <span>— Um repositório privado será criado para seu projeto</span>
+                    </li>
+                    <li>
+                      <span class="perm-label">Ver seu perfil</span>
+                      <span>— Precisamos saber seu nome de usuário</span>
+                    </li>
+                    <li>
+                      <span class="perm-label">Verificar email</span>
+                      <span>— Para vincular ao repositório</span>
+                    </li>
+                  </ul>
+                </div>
+
+                <button class="btn btn-primary btn-lg" onclick="location.href='02-repository-created.html'" style="width: 100%; margin-bottom: var(--space-3);">
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" style="margin-right: var(--space-2);">
+                    <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
+                  </svg>
+                  Conectar com GitHub
+                </button>
+
+                <div class="oauth-note">
+                  Você será redirecionado para github.com e voltará automaticamente.
+                </div>
+              </div>
+            </div>
+
+            <div class="oauth-footer">
+              Você pode revogar o acesso a qualquer momento nas configurações do GitHub.
+            </div>
+          </div>
+        </div>
+
+      </section>
+
+      <aside class="chat-panel">
+        <div class="chat-header">
+          <div class="chat-header-row">
+            <div class="chat-title">Assistente</div>
+            <button class="collapse-btn">◀</button>
+          </div>
+        </div>
+        <div class="chat-messages">
+          <div class="message">
+            <div class="message-avatar">AI</div>
+            <div class="message-content">
+              <div class="message-author">True Coding</div>
+              <div class="message-text">
+                Vamos conectar seu <strong>GitHub</strong>! 🔗
+                <br><br>
+                Isso é necessário para:
+                <br>
+                • Criar o repositório do projeto
+                <br>
+                • Fazer commits automáticos
+                <br>
+                • Configurar CI/CD
+                <br><br>
+                Clique em "Conectar com GitHub" quando estiver pronto.
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="quick-replies">
+          <div class="quick-replies-label">DÚVIDAS COMUNS</div>
+          <div class="quick-replies-buttons">
+            <button class="quick-reply-btn">É seguro?</button>
+            <button class="quick-reply-btn">Que permissões precisa?</button>
+            <button class="quick-reply-btn">Posso revogar depois?</button>
+          </div>
+        </div>
+        <div class="chat-input-container">
+          <div class="chat-input-wrapper">
+            <textarea class="chat-input" placeholder="Tire suas dúvidas..." rows="1"></textarea>
+            <button class="send-button">Enviar</button>
+          </div>
+        </div>
+      </aside>
+    </main>
+  </div>
+
+  <!-- Bottom Badge -->
+  <div style="position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%); z-index: 1000; display: flex; gap: 8px; align-items: center;">
+    <span style="padding: 8px 16px; background: #2563eb; color: white; border-radius: 20px; font-size: 13px; font-weight: 600;">Opção 1: Checkpoint Amigável</span>
+    <a href="05-opcao2-guia-visual.html" style="padding: 6px 12px; background: white; border: 1px solid #e5e7eb; border-radius: 20px; font-size: 12px; color: #4b5563; text-decoration: none;">Opção 2</a>
+    <a href="../../index.html" style="padding: 6px 12px; background: white; border: 1px solid #e5e7eb; border-radius: 20px; font-size: 12px; color: #4b5563; text-decoration: none;">← Hub</a>
+  </div>
+
+  <script>
+    function showStep(n) {
+      document.querySelectorAll('.step').forEach(el => el.style.display = 'none');
+      document.getElementById('step-' + n).style.display = 'block';
+    }
+    // Initialize
+    showStep(1);
+  </script>
+</body>
+</html>

--- a/mockups/project/phase-3-connection/05-opcao2-guia-visual.html
+++ b/mockups/project/phase-3-connection/05-opcao2-guia-visual.html
@@ -1,0 +1,1286 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Guia Visual - Conexão GitHub | True Coding</title>
+  <link rel="stylesheet" href="../../css/tokens.css">
+  <link rel="stylesheet" href="../../css/layout.css">
+  <link rel="stylesheet" href="../../css/components.css">
+  <style>
+    /* Stepper */
+    .stepper {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-bottom: var(--space-8);
+      padding: var(--space-4) 0;
+    }
+
+    .stepper-item {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      width: 100px;
+    }
+
+    .stepper-circle {
+      width: 32px;
+      height: 32px;
+      border-radius: var(--border-radius-full);
+      border: 2px solid var(--color-gray-300);
+      color: var(--color-gray-400);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: var(--font-size-sm);
+      font-weight: var(--font-weight-semibold);
+      transition: all var(--transition-normal);
+    }
+
+    .stepper-item.active .stepper-circle {
+      background: var(--color-primary);
+      border-color: var(--color-primary);
+      color: white;
+    }
+
+    .stepper-item.completed .stepper-circle {
+      background: var(--color-success);
+      border-color: var(--color-success);
+      color: white;
+    }
+
+    .stepper-label {
+      font-size: 12px;
+      margin-top: 4px;
+      color: var(--color-text-tertiary);
+      font-weight: var(--font-weight-medium);
+      transition: color var(--transition-normal);
+    }
+
+    .stepper-item.active .stepper-label {
+      color: var(--color-primary);
+    }
+
+    .stepper-item.completed .stepper-label {
+      color: var(--color-success);
+    }
+
+    .stepper-line {
+      flex: 1;
+      height: 2px;
+      background: var(--color-gray-300);
+      margin: 0 var(--space-2);
+      margin-bottom: 20px;
+      transition: background var(--transition-normal);
+    }
+
+    .stepper-line.completed {
+      background: var(--color-success);
+    }
+
+    /* Pipeline Diagram */
+    .pipeline {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0;
+      margin: var(--space-6) 0;
+      flex-wrap: wrap;
+    }
+
+    .pipeline-node {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: var(--space-2);
+      padding: var(--space-4) var(--space-5);
+      background: var(--color-bg-primary);
+      border: 2px solid var(--color-border);
+      border-radius: var(--border-radius-lg);
+      min-width: 120px;
+      transition: all var(--transition-fast);
+    }
+
+    .pipeline-node:hover {
+      border-color: var(--color-primary);
+      box-shadow: var(--shadow-sm);
+    }
+
+    .pipeline-node-icon {
+      font-size: 28px;
+    }
+
+    .pipeline-node-label {
+      font-size: var(--font-size-sm);
+      font-weight: var(--font-weight-semibold);
+      color: var(--color-text-primary);
+    }
+
+    .pipeline-arrow {
+      font-size: 24px;
+      color: var(--color-gray-400);
+      margin: 0 var(--space-2);
+    }
+
+    /* Step content area */
+    .step-content {
+      max-width: 680px;
+      margin: 0 auto;
+    }
+
+    /* Info list */
+    .info-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    .info-list li {
+      display: flex;
+      align-items: flex-start;
+      gap: var(--space-3);
+      padding: var(--space-3) 0;
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+      line-height: var(--line-height-relaxed);
+    }
+
+    .info-list li + li {
+      border-top: 1px solid var(--color-gray-100);
+    }
+
+    .info-list-number {
+      width: 24px;
+      height: 24px;
+      background: var(--color-primary-light);
+      color: var(--color-primary);
+      border-radius: var(--border-radius-full);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: var(--font-size-xs);
+      font-weight: var(--font-weight-bold);
+      flex-shrink: 0;
+    }
+
+    /* Button group */
+    .btn-group {
+      display: flex;
+      gap: var(--space-3);
+      margin-top: var(--space-6);
+    }
+
+    .btn-group .btn {
+      flex: 1;
+    }
+
+    .btn-full {
+      width: 100%;
+    }
+
+    /* Tutorial cards */
+    .tutorial-card {
+      background: var(--color-bg-primary);
+      border: 1px solid var(--color-border);
+      border-radius: var(--border-radius-lg);
+      padding: var(--space-5);
+      margin-bottom: var(--space-4);
+    }
+
+    .tutorial-card-header {
+      display: flex;
+      align-items: center;
+      gap: var(--space-3);
+      margin-bottom: var(--space-3);
+    }
+
+    .tutorial-badge {
+      width: 28px;
+      height: 28px;
+      background: var(--color-primary);
+      color: white;
+      border-radius: var(--border-radius-full);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: var(--font-size-sm);
+      font-weight: var(--font-weight-bold);
+      flex-shrink: 0;
+    }
+
+    .tutorial-card-title {
+      font-size: var(--font-size-lg);
+      font-weight: var(--font-weight-semibold);
+      color: var(--color-text-primary);
+    }
+
+    .tutorial-card-desc {
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+      line-height: var(--line-height-relaxed);
+      margin-bottom: var(--space-3);
+    }
+
+    .tutorial-illustration {
+      background: var(--color-gray-50);
+      border: 1px solid var(--color-gray-200);
+      border-radius: var(--border-radius-md);
+      padding: var(--space-4);
+      min-height: 80px;
+    }
+
+    /* GitHub homepage mockup */
+    .gh-mockup-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: var(--space-2) var(--space-3);
+      background: var(--color-gray-800);
+      border-radius: var(--border-radius-md) var(--border-radius-md) 0 0;
+    }
+
+    .gh-mockup-logo {
+      color: white;
+      font-weight: var(--font-weight-bold);
+      font-size: var(--font-size-sm);
+    }
+
+    .gh-mockup-signup {
+      background: var(--color-success);
+      color: white;
+      padding: var(--space-1) var(--space-3);
+      border-radius: var(--border-radius-md);
+      font-size: var(--font-size-xs);
+      font-weight: var(--font-weight-semibold);
+      border: 2px solid #fbbf24;
+      animation: pulseHighlight 2s infinite;
+    }
+
+    @keyframes pulseHighlight {
+      0%, 100% { border-color: #fbbf24; box-shadow: 0 0 0 0 rgba(251, 191, 36, 0.4); }
+      50% { border-color: #fbbf24; box-shadow: 0 0 0 4px rgba(251, 191, 36, 0.1); }
+    }
+
+    .gh-mockup-body {
+      background: var(--color-gray-100);
+      padding: var(--space-6);
+      border-radius: 0 0 var(--border-radius-md) var(--border-radius-md);
+      text-align: center;
+    }
+
+    .gh-mockup-body-text {
+      font-size: var(--font-size-xs);
+      color: var(--color-gray-400);
+    }
+
+    /* Form mockup */
+    .form-mockup {
+      background: white;
+      border-radius: var(--border-radius-md);
+      padding: var(--space-4);
+    }
+
+    .form-mockup-field {
+      background: var(--color-gray-100);
+      border: 1px solid var(--color-gray-200);
+      border-radius: var(--border-radius-sm);
+      padding: var(--space-2) var(--space-3);
+      margin-bottom: var(--space-2);
+      font-size: var(--font-size-xs);
+      color: var(--color-gray-400);
+    }
+
+    /* Email mockup */
+    .email-mockup {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: var(--space-3);
+      padding: var(--space-4);
+    }
+
+    .email-icon {
+      font-size: 36px;
+    }
+
+    .email-mockup-text {
+      font-size: var(--font-size-xs);
+      color: var(--color-text-tertiary);
+    }
+
+    /* Divider */
+    .divider-text {
+      display: flex;
+      align-items: center;
+      gap: var(--space-3);
+      margin: var(--space-4) 0;
+      color: var(--color-text-tertiary);
+      font-size: var(--font-size-sm);
+    }
+
+    .divider-text::before,
+    .divider-text::after {
+      content: "";
+      flex: 1;
+      height: 1px;
+      background: var(--color-border);
+    }
+
+    /* Tip box */
+    .tip-box {
+      padding: var(--space-3) var(--space-4);
+      background: var(--color-primary-light);
+      border-radius: var(--border-radius-md);
+      border-left: 3px solid var(--color-primary);
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+      line-height: var(--line-height-relaxed);
+      margin-top: var(--space-4);
+    }
+
+    /* OAuth Preview */
+    .oauth-preview {
+      background: var(--color-gray-100);
+      border-radius: var(--border-radius-lg);
+      padding: var(--space-8) var(--space-6);
+      display: flex;
+      justify-content: center;
+      margin-bottom: var(--space-5);
+      position: relative;
+    }
+
+    .oauth-card {
+      background: white;
+      border-radius: var(--border-radius-lg);
+      box-shadow: var(--shadow-lg);
+      padding: var(--space-6);
+      width: 340px;
+      text-align: center;
+    }
+
+    .oauth-logo {
+      width: 48px;
+      height: 48px;
+      background: var(--color-primary);
+      border-radius: var(--border-radius-md);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      font-weight: var(--font-weight-bold);
+      font-size: var(--font-size-lg);
+      margin: 0 auto var(--space-4);
+    }
+
+    .oauth-title {
+      font-size: var(--font-size-base);
+      font-weight: var(--font-weight-semibold);
+      color: var(--color-text-primary);
+      margin-bottom: var(--space-4);
+    }
+
+    .oauth-perms {
+      text-align: left;
+      margin-bottom: var(--space-5);
+    }
+
+    .oauth-perm {
+      display: flex;
+      align-items: center;
+      gap: var(--space-2);
+      padding: var(--space-2) 0;
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+    }
+
+    .oauth-perm-check {
+      color: var(--color-success);
+      font-weight: bold;
+    }
+
+    .oauth-authorize-btn {
+      display: block;
+      width: 100%;
+      padding: var(--space-3);
+      background: var(--color-success);
+      color: white;
+      border: none;
+      border-radius: var(--border-radius-md);
+      font-size: var(--font-size-sm);
+      font-weight: var(--font-weight-semibold);
+      cursor: default;
+    }
+
+    .oauth-annotation {
+      position: absolute;
+      right: var(--space-4);
+      bottom: var(--space-6);
+      display: flex;
+      align-items: center;
+      gap: var(--space-2);
+      background: var(--color-error);
+      color: white;
+      padding: var(--space-2) var(--space-3);
+      border-radius: var(--border-radius-md);
+      font-size: var(--font-size-xs);
+      font-weight: var(--font-weight-semibold);
+      white-space: nowrap;
+    }
+
+    .oauth-annotation::before {
+      content: "";
+      width: 24px;
+      height: 2px;
+      background: var(--color-error);
+      flex-shrink: 0;
+    }
+
+    /* Permissions detail card */
+    .perm-card {
+      background: var(--color-bg-primary);
+      border: 1px solid var(--color-border);
+      border-radius: var(--border-radius-lg);
+      padding: var(--space-5);
+      margin-bottom: var(--space-4);
+    }
+
+    .perm-card-title {
+      font-size: var(--font-size-base);
+      font-weight: var(--font-weight-semibold);
+      color: var(--color-text-primary);
+      margin-bottom: var(--space-3);
+    }
+
+    .perm-item {
+      display: flex;
+      align-items: flex-start;
+      gap: var(--space-3);
+      padding: var(--space-2) 0;
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+      line-height: var(--line-height-relaxed);
+    }
+
+    .perm-item + .perm-item {
+      border-top: 1px solid var(--color-gray-100);
+    }
+
+    .perm-icon {
+      flex-shrink: 0;
+      margin-top: 2px;
+    }
+
+    /* Security card */
+    .security-card {
+      background: var(--color-success-light);
+      border: 1px solid var(--color-success);
+      border-radius: var(--border-radius-lg);
+      padding: var(--space-5);
+      margin-bottom: var(--space-5);
+    }
+
+    .security-card-header {
+      display: flex;
+      align-items: center;
+      gap: var(--space-2);
+      margin-bottom: var(--space-2);
+    }
+
+    .security-card-title {
+      font-size: var(--font-size-base);
+      font-weight: var(--font-weight-semibold);
+      color: var(--color-text-primary);
+    }
+
+    .security-card-text {
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+      line-height: var(--line-height-relaxed);
+    }
+
+    /* Note text */
+    .note-text {
+      text-align: center;
+      font-size: var(--font-size-xs);
+      color: var(--color-text-tertiary);
+      margin-top: var(--space-3);
+    }
+
+    /* Checklist (step 4) */
+    .setup-checklist {
+      max-width: 480px;
+      margin: var(--space-8) auto 0;
+    }
+
+    .checklist-item {
+      display: flex;
+      align-items: center;
+      gap: var(--space-3);
+      padding: var(--space-4);
+      border-bottom: 1px solid var(--color-gray-100);
+      opacity: 0;
+      transform: translateY(8px);
+      animation: checklistFadeIn 0.4s ease forwards;
+    }
+
+    .checklist-item:last-child {
+      border-bottom: none;
+    }
+
+    .checklist-item:nth-child(1) { animation-delay: 0s; }
+    .checklist-item:nth-child(2) { animation-delay: 1s; }
+    .checklist-item:nth-child(3) { animation-delay: 2s; }
+    .checklist-item:nth-child(4) { animation-delay: 3s; }
+    .checklist-item:nth-child(5) { animation-delay: 3.5s; }
+
+    @keyframes checklistFadeIn {
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .checklist-icon {
+      width: 24px;
+      height: 24px;
+      border-radius: var(--border-radius-full);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 14px;
+      flex-shrink: 0;
+    }
+
+    .checklist-icon.done {
+      background: var(--color-success-light);
+      color: var(--color-success);
+    }
+
+    .checklist-icon.loading {
+      background: var(--color-primary-light);
+      color: var(--color-primary);
+      animation: spin 1s linear infinite;
+    }
+
+    .checklist-icon.pending {
+      background: var(--color-gray-100);
+      color: var(--color-gray-400);
+    }
+
+    .checklist-text {
+      font-size: var(--font-size-sm);
+      color: var(--color-text-primary);
+    }
+
+    .checklist-text.pending {
+      color: var(--color-text-tertiary);
+    }
+
+    /* Success icon (step 5) */
+    .success-icon {
+      width: 72px;
+      height: 72px;
+      background: var(--color-success-light);
+      color: var(--color-success);
+      border-radius: var(--border-radius-full);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 36px;
+      margin: 0 auto var(--space-4);
+    }
+
+    /* Repo details card */
+    .repo-card {
+      background: var(--color-bg-primary);
+      border: 1px solid var(--color-border);
+      border-radius: var(--border-radius-lg);
+      padding: var(--space-5);
+      margin-bottom: var(--space-4);
+    }
+
+    .repo-detail {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: var(--space-2) 0;
+      font-size: var(--font-size-sm);
+    }
+
+    .repo-detail + .repo-detail {
+      border-top: 1px solid var(--color-gray-100);
+    }
+
+    .repo-detail-label {
+      color: var(--color-text-tertiary);
+    }
+
+    .repo-detail-value {
+      color: var(--color-text-primary);
+      font-weight: var(--font-weight-medium);
+      display: flex;
+      align-items: center;
+      gap: var(--space-2);
+    }
+
+    .copy-btn {
+      padding: var(--space-1) var(--space-2);
+      background: var(--color-bg-secondary);
+      border: 1px solid var(--color-border);
+      border-radius: var(--border-radius-sm);
+      font-size: var(--font-size-xs);
+      color: var(--color-text-tertiary);
+      cursor: pointer;
+      transition: all var(--transition-fast);
+    }
+
+    .copy-btn:hover {
+      background: var(--color-bg-tertiary);
+      color: var(--color-text-primary);
+    }
+
+    /* Next step card */
+    .next-step-card {
+      background: var(--color-primary-light);
+      border: 1px solid var(--color-primary);
+      border-radius: var(--border-radius-lg);
+      padding: var(--space-5);
+      margin-bottom: var(--space-5);
+    }
+
+    .next-step-card p {
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+      line-height: var(--line-height-relaxed);
+      margin: 0;
+    }
+
+    .next-step-card-header {
+      font-size: var(--font-size-base);
+      font-weight: var(--font-weight-semibold);
+      color: var(--color-text-primary);
+      margin-bottom: var(--space-2);
+    }
+
+    /* Chat message groups */
+    .chat-group {
+      display: none;
+    }
+
+    .chat-group.visible {
+      display: contents;
+    }
+  </style>
+</head>
+<body>
+  <div class="app-layout">
+    <!-- SIDEBAR -->
+    <aside class="sidebar">
+      <div class="sidebar-header">
+        <div class="logo">
+          <div class="logo-icon">TC</div>
+          <span>True Coding</span>
+        </div>
+        <div class="project-name">Meu App Delivery</div>
+        <a href="../../dashboard/list.html" class="back-link">&larr; Dashboard</a>
+        <div class="journey-progress">
+          <div class="journey-progress-header">
+            <span class="journey-label">JORNADA</span>
+            <span class="journey-count">Fase 3/6</span>
+          </div>
+          <div class="journey-dots">
+            <div class="journey-dot completed"></div>
+            <div class="journey-dot completed"></div>
+            <div class="journey-dot current"></div>
+            <div class="journey-dot"></div>
+            <div class="journey-dot"></div>
+            <div class="journey-dot"></div>
+          </div>
+        </div>
+      </div>
+      <nav class="sidebar-nav">
+        <div class="nav-section">
+          <div class="nav-section-title">FASES</div>
+          <div class="nav-item completed"><span class="phase-icon"></span><span>Ideação</span></div>
+          <div class="nav-item completed"><span class="phase-icon"></span><span>Planejamento</span></div>
+          <a href="#" class="nav-item in-progress"><span class="phase-icon"></span><span>Conexão</span></a>
+          <div class="nav-item blocked"><span class="phase-icon"></span><span>Geração</span></div>
+          <div class="nav-item blocked"><span class="phase-icon"></span><span>Deploy</span></div>
+          <div class="nav-item blocked"><span class="phase-icon"></span><span>Online</span></div>
+        </div>
+      </nav>
+      <div class="sidebar-footer">
+        <div class="user-info">
+          <div class="user-avatar">RN</div>
+          <div class="user-details">
+            <div class="user-name">Renato Natali</div>
+            <div class="user-email">renato@email.com</div>
+          </div>
+        </div>
+      </div>
+    </aside>
+
+    <!-- MAIN CONTENT -->
+    <main class="main-content">
+      <section class="workspace">
+
+        <!-- ============================================================ -->
+        <!-- STEP 1: Boas-vindas                                          -->
+        <!-- ============================================================ -->
+        <div class="step" id="step-1">
+          <div class="stepper" id="stepper-step-1">
+            <div class="stepper-item active">
+              <div class="stepper-circle">1</div>
+              <div class="stepper-label">Preparar</div>
+            </div>
+            <div class="stepper-line"></div>
+            <div class="stepper-item">
+              <div class="stepper-circle">2</div>
+              <div class="stepper-label">Conectar</div>
+            </div>
+            <div class="stepper-line"></div>
+            <div class="stepper-item">
+              <div class="stepper-circle">3</div>
+              <div class="stepper-label">Pronto</div>
+            </div>
+          </div>
+
+          <div class="step-content">
+            <div class="workspace-header" style="text-align: center;">
+              <h2 class="workspace-title">Vamos colocar seu projeto no ar</h2>
+              <p class="workspace-subtitle">São 3 passos rápidos para conectar tudo. Você vai precisar de uma conta no GitHub.</p>
+            </div>
+
+            <!-- Pipeline Diagram -->
+            <div class="pipeline">
+              <div class="pipeline-node">
+                <div class="pipeline-node-icon">TC</div>
+                <div class="pipeline-node-label">True Coding</div>
+              </div>
+              <div class="pipeline-arrow">&rarr;</div>
+              <div class="pipeline-node">
+                <div class="pipeline-node-icon">
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+                </div>
+                <div class="pipeline-node-label">GitHub</div>
+              </div>
+              <div class="pipeline-arrow">&rarr;</div>
+              <div class="pipeline-node">
+                <div class="pipeline-node-icon">
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M24 22.525H0l12-21.05 12 21.05z"/></svg>
+                </div>
+                <div class="pipeline-node-label">Vercel</div>
+              </div>
+              <div class="pipeline-arrow">&rarr;</div>
+              <div class="pipeline-node">
+                <div class="pipeline-node-icon">&#127760;</div>
+                <div class="pipeline-node-label">Seu App Online</div>
+              </div>
+            </div>
+
+            <!-- What will happen card -->
+            <div style="background: var(--color-bg-primary); border: 1px solid var(--color-border); border-radius: var(--border-radius-lg); padding: var(--space-5); margin-bottom: var(--space-6);">
+              <div style="font-size: var(--font-size-base); font-weight: var(--font-weight-semibold); color: var(--color-text-primary); margin-bottom: var(--space-3);">
+                O que vai acontecer?
+              </div>
+              <ul class="info-list">
+                <li>
+                  <span class="info-list-number">1</span>
+                  <span>Você conecta sua conta do GitHub (como um login)</span>
+                </li>
+                <li>
+                  <span class="info-list-number">2</span>
+                  <span>Criamos um repositório privado para guardar o código do <strong>Meu App Delivery</strong></span>
+                </li>
+                <li>
+                  <span class="info-list-number">3</span>
+                  <span>Conectamos ao Vercel para publicar seu app automaticamente</span>
+                </li>
+              </ul>
+            </div>
+
+            <!-- Question -->
+            <div style="text-align: center; margin-bottom: var(--space-4);">
+              <p style="font-size: var(--font-size-lg); font-weight: var(--font-weight-semibold); color: var(--color-text-primary);">
+                Você já tem uma conta no GitHub?
+              </p>
+            </div>
+
+            <div class="btn-group" style="max-width: 400px; margin: 0 auto;">
+              <button class="btn btn-primary btn-lg" onclick="showStep(3)">Sim, vamos lá</button>
+              <button class="btn btn-secondary btn-lg" onclick="showStep(2)">Não tenho, me ajude</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- ============================================================ -->
+        <!-- STEP 2: Tutorial Criar Conta                                 -->
+        <!-- ============================================================ -->
+        <div class="step" id="step-2" style="display: none;">
+          <div class="stepper" id="stepper-step-2">
+            <div class="stepper-item active">
+              <div class="stepper-circle">1</div>
+              <div class="stepper-label">Preparar</div>
+            </div>
+            <div class="stepper-line"></div>
+            <div class="stepper-item">
+              <div class="stepper-circle">2</div>
+              <div class="stepper-label">Conectar</div>
+            </div>
+            <div class="stepper-line"></div>
+            <div class="stepper-item">
+              <div class="stepper-circle">3</div>
+              <div class="stepper-label">Pronto</div>
+            </div>
+          </div>
+
+          <div class="step-content">
+            <div class="workspace-header" style="text-align: center;">
+              <h2 class="workspace-title">Criar conta no GitHub</h2>
+              <p class="workspace-subtitle">Vamos te guiar passo a passo. Leva menos de 2 minutos.</p>
+            </div>
+
+            <!-- Tutorial Card 1 -->
+            <div class="tutorial-card">
+              <div class="tutorial-card-header">
+                <div class="tutorial-badge">1</div>
+                <div class="tutorial-card-title">Acesse github.com</div>
+              </div>
+              <div class="tutorial-card-desc">
+                Clique no botão verde <strong>Sign up</strong> no canto superior direito da página.
+              </div>
+              <div class="tutorial-illustration">
+                <div class="gh-mockup-header">
+                  <span class="gh-mockup-logo">GitHub</span>
+                  <span class="gh-mockup-signup">Sign up</span>
+                </div>
+                <div class="gh-mockup-body">
+                  <div class="gh-mockup-body-text">Build and ship software on a single, collaborative platform</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Tutorial Card 2 -->
+            <div class="tutorial-card">
+              <div class="tutorial-card-header">
+                <div class="tutorial-badge">2</div>
+                <div class="tutorial-card-title">Preencha seus dados</div>
+              </div>
+              <div class="tutorial-card-desc">
+                Informe seu <strong>email</strong>, crie uma <strong>senha</strong> e escolha um <strong>nome de usuário</strong>. Na opção de plano, selecione <strong>Free</strong> (gratuito).
+              </div>
+              <div class="tutorial-illustration">
+                <div class="form-mockup">
+                  <div class="form-mockup-field">Enter your email</div>
+                  <div class="form-mockup-field">Create a password</div>
+                  <div class="form-mockup-field">Enter a username</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Tutorial Card 3 -->
+            <div class="tutorial-card">
+              <div class="tutorial-card-header">
+                <div class="tutorial-badge">3</div>
+                <div class="tutorial-card-title">Confirme seu email</div>
+              </div>
+              <div class="tutorial-card-desc">
+                O GitHub vai enviar um <strong>código de verificação</strong> para o email que você informou. Abra seu email, copie o código e cole no GitHub.
+              </div>
+              <div class="tutorial-illustration">
+                <div class="email-mockup">
+                  <div class="email-icon">&#9993;&#65039;</div>
+                  <div>
+                    <div style="font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--color-text-primary);">Verifique sua caixa de entrada</div>
+                    <div class="email-mockup-text">Copie o código de 6 dígitos e cole no GitHub</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Actions -->
+            <a href="https://github.com/signup" target="_blank" class="btn btn-primary btn-lg btn-full" style="text-align: center;">
+              Abrir GitHub para criar conta
+            </a>
+
+            <div class="divider-text">ou</div>
+
+            <button class="btn btn-secondary btn-lg btn-full" onclick="showStep(3)">
+              Já criei minha conta
+            </button>
+
+            <div class="tip-box">
+              <strong>Dica:</strong> Use o mesmo email que você usa no True Coding. Fica mais fácil de gerenciar.
+            </div>
+          </div>
+        </div>
+
+        <!-- ============================================================ -->
+        <!-- STEP 3: Preview OAuth                                        -->
+        <!-- ============================================================ -->
+        <div class="step" id="step-3" style="display: none;">
+          <div class="stepper" id="stepper-step-3">
+            <div class="stepper-item completed">
+              <div class="stepper-circle">&#10003;</div>
+              <div class="stepper-label">Preparar</div>
+            </div>
+            <div class="stepper-line completed"></div>
+            <div class="stepper-item active">
+              <div class="stepper-circle">2</div>
+              <div class="stepper-label">Conectar</div>
+            </div>
+            <div class="stepper-line"></div>
+            <div class="stepper-item">
+              <div class="stepper-circle">3</div>
+              <div class="stepper-label">Pronto</div>
+            </div>
+          </div>
+
+          <div class="step-content">
+            <div class="workspace-header" style="text-align: center;">
+              <h2 class="workspace-title">Autorizar acesso ao GitHub</h2>
+              <p class="workspace-subtitle">Quando você clicar no botão abaixo, verá uma tela parecida com esta:</p>
+            </div>
+
+            <!-- OAuth Preview Mockup -->
+            <div class="oauth-preview">
+              <div class="oauth-card">
+                <div class="oauth-logo">TC</div>
+                <div class="oauth-title">True Coding wants to access your<br><strong>renatomnatali</strong> account</div>
+                <div class="oauth-perms">
+                  <div class="oauth-perm"><span class="oauth-perm-check">&#10003;</span> Public and private repositories</div>
+                  <div class="oauth-perm"><span class="oauth-perm-check">&#10003;</span> Read user profile data</div>
+                  <div class="oauth-perm"><span class="oauth-perm-check">&#10003;</span> Read user email addresses</div>
+                </div>
+                <button class="oauth-authorize-btn">Authorize True Coding</button>
+              </div>
+              <div class="oauth-annotation">
+                Clique em 'Authorize' (botão verde) para autorizar
+              </div>
+            </div>
+
+            <!-- Permissions Card -->
+            <div class="perm-card">
+              <div class="perm-card-title">O que estamos pedindo:</div>
+              <div class="perm-item">
+                <span class="perm-icon">&#128230;</span>
+                <span><strong>Criar repositório</strong> &mdash; Vamos criar um repositório privado chamado <strong>meu-app-delivery</strong></span>
+              </div>
+              <div class="perm-item">
+                <span class="perm-icon">&#128100;</span>
+                <span><strong>Ver seu perfil</strong> &mdash; Apenas para identificar seu nome de usuário</span>
+              </div>
+              <div class="perm-item">
+                <span class="perm-icon">&#9993;</span>
+                <span><strong>Verificar email</strong> &mdash; Para configurar os commits com seu nome</span>
+              </div>
+            </div>
+
+            <!-- Security Card -->
+            <div class="security-card">
+              <div class="security-card-header">
+                <span>&#128272;</span>
+                <span class="security-card-title">Seus dados estão seguros</span>
+              </div>
+              <div class="security-card-text">
+                Não acessamos seus repositórios existentes. Não modificamos nada na sua conta. Você pode revogar o acesso a qualquer momento em github.com &gt; Settings &gt; Applications.
+              </div>
+            </div>
+
+            <!-- Connect Button -->
+            <button class="btn btn-primary btn-lg btn-full" onclick="showStep(4)">
+              Conectar com GitHub
+            </button>
+
+            <p class="note-text">
+              Você será redirecionado para github.com e voltará automaticamente após autorizar.
+            </p>
+          </div>
+        </div>
+
+        <!-- ============================================================ -->
+        <!-- STEP 4: Criando Repositório                                  -->
+        <!-- ============================================================ -->
+        <div class="step" id="step-4" style="display: none;">
+          <div class="stepper" id="stepper-step-4">
+            <div class="stepper-item completed">
+              <div class="stepper-circle">&#10003;</div>
+              <div class="stepper-label">Preparar</div>
+            </div>
+            <div class="stepper-line completed"></div>
+            <div class="stepper-item completed">
+              <div class="stepper-circle">&#10003;</div>
+              <div class="stepper-label">Conectar</div>
+            </div>
+            <div class="stepper-line completed"></div>
+            <div class="stepper-item active">
+              <div class="stepper-circle">3</div>
+              <div class="stepper-label">Pronto</div>
+            </div>
+          </div>
+
+          <div class="step-content" style="text-align: center;">
+            <div class="workspace-header">
+              <h2 class="workspace-title">Configurando seu repositório...</h2>
+            </div>
+
+            <div class="setup-checklist">
+              <div class="checklist-item">
+                <div class="checklist-icon done">&#10003;</div>
+                <div class="checklist-text">Conta GitHub verificada</div>
+              </div>
+              <div class="checklist-item">
+                <div class="checklist-icon done">&#10003;</div>
+                <div class="checklist-text">Permissões confirmadas</div>
+              </div>
+              <div class="checklist-item">
+                <div class="checklist-icon loading">&#8635;</div>
+                <div class="checklist-text">Criando repositório <strong>meu-app-delivery</strong>...</div>
+              </div>
+              <div class="checklist-item">
+                <div class="checklist-icon pending">&#9675;</div>
+                <div class="checklist-text pending">Configurando branch principal</div>
+              </div>
+              <div class="checklist-item">
+                <div class="checklist-icon pending">&#9675;</div>
+                <div class="checklist-text pending">Adicionando arquivos iniciais</div>
+              </div>
+            </div>
+
+            <p class="note-text" style="margin-top: var(--space-6);">
+              Isso leva alguns segundos. Não feche esta página.
+            </p>
+          </div>
+        </div>
+
+        <!-- ============================================================ -->
+        <!-- STEP 5: Repositório Criado                                   -->
+        <!-- ============================================================ -->
+        <div class="step" id="step-5" style="display: none;">
+          <div class="stepper" id="stepper-step-5">
+            <div class="stepper-item completed">
+              <div class="stepper-circle">&#10003;</div>
+              <div class="stepper-label">Preparar</div>
+            </div>
+            <div class="stepper-line completed"></div>
+            <div class="stepper-item completed">
+              <div class="stepper-circle">&#10003;</div>
+              <div class="stepper-label">Conectar</div>
+            </div>
+            <div class="stepper-line completed"></div>
+            <div class="stepper-item completed">
+              <div class="stepper-circle">&#10003;</div>
+              <div class="stepper-label">Pronto</div>
+            </div>
+          </div>
+
+          <div class="step-content" style="text-align: center;">
+            <div class="success-icon">&#10003;</div>
+
+            <div class="workspace-header">
+              <h2 class="workspace-title">Repositório criado com sucesso!</h2>
+              <p class="workspace-subtitle">Seu código já tem um lar. Agora vamos conectar o deploy.</p>
+            </div>
+
+            <!-- Repo details -->
+            <div class="repo-card" style="text-align: left;">
+              <div class="repo-detail">
+                <span class="repo-detail-label">URL</span>
+                <span class="repo-detail-value">
+                  github.com/renatomnatali/meu-app-delivery
+                  <button class="copy-btn" onclick="navigator.clipboard.writeText('https://github.com/renatomnatali/meu-app-delivery')">Copiar</button>
+                </span>
+              </div>
+              <div class="repo-detail">
+                <span class="repo-detail-label">Visibilidade</span>
+                <span class="repo-detail-value">Privado &#128274;</span>
+              </div>
+              <div class="repo-detail">
+                <span class="repo-detail-label">Branch</span>
+                <span class="repo-detail-value">main</span>
+              </div>
+              <div class="repo-detail">
+                <span class="repo-detail-label">Arquivos</span>
+                <span class="repo-detail-value">README.md, .gitignore, package.json</span>
+              </div>
+            </div>
+
+            <!-- Next step card -->
+            <div class="next-step-card" style="text-align: left;">
+              <div class="next-step-card-header">Próximo passo</div>
+              <p>Agora vamos conectar o <strong>Vercel</strong> para que seu app fique disponível na internet automaticamente.</p>
+            </div>
+
+            <div class="btn-group" style="max-width: 480px; margin: 0 auto;">
+              <a href="https://github.com/renatomnatali/meu-app-delivery" target="_blank" class="btn btn-secondary btn-lg">Ver no GitHub</a>
+              <button class="btn btn-primary btn-lg" style="flex: 1;">Conectar Vercel &rarr;</button>
+            </div>
+          </div>
+        </div>
+
+      </section>
+
+      <!-- CHAT PANEL -->
+      <aside class="chat-panel">
+        <div class="chat-header">
+          <div class="chat-header-row">
+            <div class="chat-title">Assistente</div>
+            <button class="collapse-btn">&#9664;</button>
+          </div>
+        </div>
+        <div class="chat-messages" id="chat-messages">
+          <!-- Group: Steps 1-2 -->
+          <div class="chat-group visible" id="chat-group-1">
+            <div class="message">
+              <div class="message-avatar">AI</div>
+              <div class="message-content">
+                <div class="message-author">True Coding</div>
+                <div class="message-text">
+                  Vamos conectar seu <strong>GitHub</strong>! &#128279;
+                  <br><br>
+                  São 3 passos rápidos. Estou aqui se precisar de ajuda.
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Group: Step 3 -->
+          <div class="chat-group" id="chat-group-3">
+            <div class="message">
+              <div class="message-avatar">AI</div>
+              <div class="message-content">
+                <div class="message-author">True Coding</div>
+                <div class="message-text">
+                  Quando clicar em 'Conectar', você será levado ao GitHub por alguns segundos. É só clicar no botão verde 'Authorize' e vai voltar automaticamente pra cá. &#128077;
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Group: Steps 4-5 -->
+          <div class="chat-group" id="chat-group-4">
+            <div class="message">
+              <div class="message-avatar">AI</div>
+              <div class="message-content">
+                <div class="message-author">True Coding</div>
+                <div class="message-text">
+                  Repositório criado! &#9989;
+                  <br><br>
+                  Seu código já tem um lar seguro no GitHub. Agora falta só o Vercel para publicar.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="quick-replies" id="quick-replies">
+          <div class="quick-replies-label">DÚVIDAS COMUNS</div>
+          <div class="quick-replies-buttons" id="quick-replies-buttons">
+            <button class="quick-reply-btn">O que é GitHub?</button>
+            <button class="quick-reply-btn">É seguro?</button>
+            <button class="quick-reply-btn">Posso usar outra plataforma?</button>
+          </div>
+        </div>
+
+        <div class="chat-input-container">
+          <div class="chat-input-wrapper">
+            <textarea class="chat-input" placeholder="Tire suas dúvidas..." rows="1"></textarea>
+            <button class="send-button">Enviar</button>
+          </div>
+        </div>
+      </aside>
+    </main>
+  </div>
+
+  <!-- Bottom Badge -->
+  <div style="position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%); z-index: 1000; display: flex; gap: 8px; align-items: center;">
+    <a href="04-opcao1-checkpoint.html" style="padding: 6px 12px; background: white; border: 1px solid #e5e7eb; border-radius: 20px; font-size: 12px; color: #4b5563; text-decoration: none;">Opção 1</a>
+    <span style="padding: 8px 16px; background: #2563eb; color: white; border-radius: 20px; font-size: 13px; font-weight: 600;">Opção 2: Guia Visual</span>
+    <a href="../../index.html" style="padding: 6px 12px; background: white; border: 1px solid #e5e7eb; border-radius: 20px; font-size: 12px; color: #4b5563; text-decoration: none;">&larr; Hub</a>
+  </div>
+
+  <script>
+    var autoAdvanceTimer = null;
+
+    function showStep(n) {
+      // Hide all steps
+      document.querySelectorAll('.step').forEach(function(el) {
+        el.style.display = 'none';
+      });
+
+      // Show target step
+      var target = document.getElementById('step-' + n);
+      if (target) {
+        target.style.display = 'block';
+      }
+
+      // Update chat
+      updateChat(n);
+
+      // Clear any existing auto-advance timer
+      if (autoAdvanceTimer) {
+        clearTimeout(autoAdvanceTimer);
+        autoAdvanceTimer = null;
+      }
+
+      // Auto-advance from step 4 to step 5
+      if (n === 4) {
+        autoAdvanceTimer = setTimeout(function() {
+          showStep(5);
+        }, 4000);
+      }
+    }
+
+    function updateChat(step) {
+      // Chat group visibility
+      var group1 = document.getElementById('chat-group-1');
+      var group3 = document.getElementById('chat-group-3');
+      var group4 = document.getElementById('chat-group-4');
+
+      // Groups 1 is always visible
+      group1.classList.add('visible');
+
+      // Group 3 visible from step 3 onward
+      if (step >= 3) {
+        group3.classList.add('visible');
+      } else {
+        group3.classList.remove('visible');
+      }
+
+      // Group 4 visible from step 4 onward
+      if (step >= 4) {
+        group4.classList.add('visible');
+      } else {
+        group4.classList.remove('visible');
+      }
+
+      // Update quick replies based on step
+      var qrButtons = document.getElementById('quick-replies-buttons');
+      if (step <= 2) {
+        qrButtons.innerHTML =
+          '<button class="quick-reply-btn">O que é GitHub?</button>' +
+          '<button class="quick-reply-btn">É seguro?</button>' +
+          '<button class="quick-reply-btn">Posso usar outra plataforma?</button>';
+      } else if (step === 3) {
+        qrButtons.innerHTML =
+          '<button class="quick-reply-btn">O que é Authorize?</button>' +
+          '<button class="quick-reply-btn">É seguro autorizar?</button>' +
+          '<button class="quick-reply-btn">Quais permissões?</button>';
+      } else {
+        qrButtons.innerHTML =
+          '<button class="quick-reply-btn">Como vejo meu repositório?</button>' +
+          '<button class="quick-reply-btn">O que é Vercel?</button>' +
+          '<button class="quick-reply-btn">Posso editar o código?</button>';
+      }
+
+      // Scroll chat to bottom
+      var chatMessages = document.getElementById('chat-messages');
+      chatMessages.scrollTop = chatMessages.scrollHeight;
+    }
+
+    // Initialize
+    showStep(1);
+  </script>
+</body>
+</html>

--- a/src/components/project/WorkspacePanel.tsx
+++ b/src/components/project/WorkspacePanel.tsx
@@ -733,7 +733,7 @@ function TechnicalPlanView({
               <div key={i}>
                 <p className="mb-2 text-xs font-semibold uppercase text-gray-500">{cat.name}</p>
                 <div className="flex flex-wrap gap-2">
-                  {cat.technologies.map((tech, j) => (
+                  {cat.technologies?.map((tech, j) => (
                     <span key={j} className="rounded-md bg-muted px-2 py-1 text-sm">{tech}</span>
                   ))}
                 </div>
@@ -792,7 +792,7 @@ function TechnicalPlanView({
               <div key={i}>
                 <p className="mb-2 text-xs font-semibold uppercase text-gray-500">{group.category}</p>
                 <div className="space-y-2">
-                  {group.endpoints.map((ep, j) => (
+                  {group.endpoints?.map((ep, j) => (
                     <div key={j} className="rounded-lg bg-muted/50 p-3 font-mono text-xs">
                       <div className="flex items-center gap-2">
                         <MethodBadge method={ep.method} />
@@ -822,7 +822,7 @@ function TechnicalPlanView({
                 <div key={i} className="rounded-lg bg-muted/50 p-3">
                   <p className="mb-2 font-semibold"><code className="rounded bg-black/10 px-1 py-0.5">{channel.name}</code></p>
                   <ul className="space-y-1 pl-4 text-xs text-muted-foreground">
-                    {channel.events.map((ev, j) => (
+                    {channel.events?.map((ev, j) => (
                       <li key={j}><code>{ev.name}</code> - {ev.description}</li>
                     ))}
                   </ul>


### PR DESCRIPTION
## Summary
- Add triaging step "Você já tem GitHub?" with two paths: "Sim, já tenho" → OAuth and "Ainda não tenho" → tutorial to create account → OAuth
- Fix crash in TechnicalPlanView when AI-generated real-time channels lack `events` array (optional chaining)
- Add Rule 6 to CLAUDE.md (Portuguese text must always include proper diacritics)
- Include HTML mockups for Option 1 (Checkpoint) and Option 2 (Guia Visual)

## Changes
- `ConnectionPhase.tsx`: New `CheckpointView`, `CreateAccountView`, `GitHubCheckpointFlow` components
- `connection.feature`: 5 new Gherkin scenarios for checkpoint flow
- `connection.steps.tsx`: 3 new test describes (13 tests) replacing old OAuth-direct tests
- `WorkspacePanel.tsx`: Optional chaining on 3 nested `.map()` calls

## Test plan
- [x] `npm test` — 279 tests passing
- [x] `npm run lint` — no errors
- [ ] Manual: navigate to project in CONNECTING status, verify checkpoint → create account → OAuth flow
- [ ] Manual: verify "Sim, já tenho" goes directly to OAuth
- [ ] Manual: create new project that generates real-time channels, verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)