### PR TITLE
fix(planning): fix disappearing messages, typography preview, progressive loading

### DIFF
--- a/src/components/project/ChatPanel.tsx
+++ b/src/components/project/ChatPanel.tsx
@@ -195,14 +195,15 @@ export function ChatPanel({
                 console.log('[CHAT] Plan ready detected! Plan:', parsed.plan)
                 setIsGeneratingPlan(false)
                 setPlanReady(true)
-                // Replace message with confirmation instead of showing JSON
-                setMessages((prev) =>
-                  prev.map((m) =>
-                    m.id === assistantMessage.id
-                      ? { ...m, content: 'Plano gerado com sucesso! Veja o resumo ao lado e me diga se quer ajustar algo.' }
-                      : m
-                  )
-                )
+                // Add a separate confirmation message (don't replace the streamed content — stripJsonFromDisplay handles display)
+                setMessages((prev) => [
+                  ...prev,
+                  {
+                    id: crypto.randomUUID(),
+                    role: 'assistant' as const,
+                    content: 'Plano gerado com sucesso! Veja o resumo ao lado e me diga se quer ajustar algo.',
+                  },
+                ])
                 onPlanReady?.(parsed.plan)
               }
               // 'done' and 'error' events are handled implicitly


### PR DESCRIPTION
## Summary
- **Fix #37**: Last chat Q&A disappears when plan is generated — create a new confirmation message instead of replacing the streamed assistant content
- **Fix #40**: Typography labels in Design Tokens now render with the actual font size and weight they describe (visual preview)
- **Fix #38**: UX Plan loading screen shows progressive messages cycling through each section (~15s each) with dot progress indicator

## Test plan
- [x] All 288 tests passing (`npm test`)
- [x] Lint clean (`npm run lint`)
- [ ] Manual: Complete Discovery Q5 → confirm last message stays visible
- [ ] Manual: View Design Tokens → Typography labels show correct sizes
- [ ] Manual: Approve Technical Plan → see progressive loading messages

Closes #37 Closes #38 Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)