### PR TITLE
feat(planning): add visual previews for UX Plan sections

### DIFF
--- a/docs/UX-SPEC-VISUAL-SECTIONS.md
+++ b/docs/UX-SPEC-VISUAL-SECTIONS.md
@@ -1,0 +1,311 @@
+# UX Spec: Representacao Visual das Secoes do UX Plan (Issue #39)
+
+> **Autor:** UX Planning Agent
+> **Data:** 12 Fev 2026
+> **Status:** Proposta para validacao
+
+---
+
+## A. Resumo do Problema e Objetivos
+
+### Problema do Usuario
+Na fase de Planejamento, o UX Plan gera 8 secoes. Tres delas descrevem elementos visuais
+(Navegacao Principal, Wireframes e Fluxos, Biblioteca de Componentes) mas sao exibidas
+apenas como texto descritivo. O usuario precisa "imaginar" o layout, tornando a revisao
+e aprovacao do plano menos eficaz.
+
+### Objetivo do Usuario
+Visualizar representacoes esquematicas (wireframes simplificados) de cada secao visual
+diretamente no workspace, sem precisar sair da plataforma ou interpretar texto puro.
+
+### Objetivo de Negocio
+- Aumentar a confianca do usuario na aprovacao do UX Plan
+- Reduzir pedidos de revisao por mal-entendidos visuais
+- Diferenciar o True Coding de ferramentas que geram apenas texto
+
+### Criterios de Sucesso
+1. As 3 secoes visuais renderizam representacoes HTML/CSS/SVG baseadas no JSON da IA
+2. Fidelidade "esquematica" -- wireframe simplificado, nao mockup pixel-perfect
+3. Responsivo (funciona em desktop e mobile)
+4. Acessivel (WCAG 2.2 AA)
+5. Nao requer geracao de imagens por IA
+
+---
+
+## B. Premissas e Restricoes
+
+### Fatos
+- O JSON do UX Plan ja contem campos `wireframes`, `componentLibrary` e `informationArchitecture.navigation`
+- O componente `UxPlanView` no `WorkspacePanel.tsx` ja renderiza todas as 8 secoes
+- A stack usa React 19, Tailwind CSS e shadcn/ui
+- O workspace tem largura max de `max-w-3xl` (768px)
+
+### Hipoteses (a validar)
+- **H1:** Usuarios preferem wireframes esquematicos a descricoes textuais longas
+- **H2:** O campo `layout` dos wireframes contem informacao suficiente para inferir grid/disposicao
+- **H3:** 3-5 variantes de componente por grupo sao suficientes para comunicar o design system
+
+### Restricoes Tecnicas
+- Sem geracao de imagens por IA (SVG/HTML/CSS renderizado no React)
+- O JSON nao muda de estrutura -- a renderizacao visual e uma "camada de apresentacao"
+- Performance: renderizar inline, sem lazy load complexo
+- Sem dependencias externas novas (usar apenas Tailwind + SVG nativo)
+
+---
+
+## C. Persona
+
+### Persona Primaria: Empreendedor Criador (usuario do True Coding)
+
+| Campo | Detalhe |
+|-------|---------|
+| Nome | Ricardo Alves |
+| Idade | 35 anos |
+| Localizacao | Campinas, SP |
+| Contexto | Tem uma ideia de app, nao e programador, esta usando True Coding para transformar a ideia em produto |
+| JTBD | "Quero entender visualmente como meu app vai funcionar antes de aprovar o plano" |
+| Dores | Texto puro nao comunica layout; precisa "adivinhar" como as telas vao ficar |
+| Objetivos | Aprovar o UX Plan com confianca de que o resultado final sera proximo do que imagina |
+| Triggers | Acabou de aprovar o Technical Plan, esta revisando o UX Plan |
+| Acessibilidade | Sem necessidades especiais, mas usa celular frequentemente |
+
+---
+
+## D. Jornada Detalhada
+
+### Jornada: Revisar e Aprovar Secoes Visuais do UX Plan
+
+| Passo | Acao | Emocao | Friccao Potencial |
+|-------|------|--------|-------------------|
+| 1 | Ricardo aprova Technical Plan e aguarda geracao do UX Plan | Ansioso | Loading de ~2 min |
+| 2 | UX Plan aparece. Scrolla pelas Personas e Jornadas (texto) | Neutro | Texto longo |
+| 3 | Chega na secao "Arquitetura de Informacao" com Navegacao Principal | **Positivo** se visual, **Negativo** se so texto | Texto puro = "como isso vai ficar?" |
+| 4 | Ve representacao visual da sidebar/tabs/bottom bar | Confiante | Precisa entender que e esquematico |
+| 5 | Scrolla ate "Wireframes e Fluxos" | **Positivo** se ve layouts | Muito texto = desiste de ler |
+| 6 | Ve wireframes esquematicos com grid, sidebar, cards | Empolgado | Layout pode nao corresponder a expectativa |
+| 7 | Chega na "Biblioteca de Componentes" | **Positivo** se ve preview | Nomes de variantes sao abstratos |
+| 8 | Ve preview visual de botoes, badges, cards, inputs | Confiante | Precisa distinguir variantes |
+| 9 | Clica "Aprovar e Continuar" | Satisfeito | -- |
+
+### Pontos de Recuperacao
+- Se o wireframe nao corresponde a expectativa: usuario pode pedir ajustes no chat
+- Se o layout inferido esta errado: texto descritivo permanece visivel como fallback
+
+---
+
+## E. Fluxos e Requisitos
+
+### Happy Path
+1. UX Plan e gerado com JSON completo
+2. Secoes visuais renderizam automaticamente baseadas nos dados
+3. Usuario scrolla, revisa, aprova
+
+### Edge Cases
+1. **JSON sem campo `layout`**: Renderizar wireframe generico com placeholder
+2. **Wireframe com layout nao reconhecido**: Mostrar texto descritivo + wireframe generico
+3. **Lista de componentes vazia**: Mostrar estado vazio com mensagem
+4. **Navegacao com apenas 1 item**: Renderizar normalmente
+5. **Tela mobile**: Wireframes empilham verticalmente, reduzem escala
+
+### Regras de Renderizacao Visual
+
+#### Secao 1: Navegacao Principal (`informationArchitecture.navigation`)
+- Detectar padrao pelo campo `name`: "Sidebar" -> wireframe sidebar, "Bottom" -> wireframe bottom bar, "Tabs" -> wireframe tabs, "Breadcrumb" -> wireframe breadcrumb
+- Cada padrao renderiza um SVG/HTML esquematico
+- Label do padrao visivel abaixo do wireframe
+- Fallback: texto descritivo se padrao nao reconhecido
+
+#### Secao 2: Wireframes e Fluxos (`wireframes`)
+- Detectar layout pelo campo `layout`: "Sidebar" -> grid 2 colunas, "Grid" -> grid de cards, "List" -> lista vertical, "Form" -> formulario com campos, "Map" -> area de mapa com sidebar
+- Renderizar wireframe esquematico com areas cinzas representando zonas de conteudo
+- Nome da tela como titulo do wireframe
+- Descricao abaixo do wireframe
+- Maximo 4 wireframes visiveis, scroll horizontal para mais
+
+#### Secao 3: Biblioteca de Componentes (`componentLibrary`)
+- Para cada grupo, renderizar preview visual das variantes
+- "Buttons": Botoes reais com estilos diferenciados (primary, secondary, destructive, ghost)
+- "Badges"/"Status": Pills coloridas com texto
+- "Cards": Retangulos com borda e conteudo esquematico
+- "Form Inputs"/"Inputs": Campos de formulario com label e placeholder
+- Fallback para grupos nao reconhecidos: chips com nome da variante
+
+---
+
+## F. Especificacao UX/UI
+
+### F.1 Navegacao Principal -- Wireframes de Padroes
+
+#### Componente: `NavigationPreview`
+- **Entrada**: Array de `{ name, description }`
+- **Saida**: Grid de wireframes esquematicos (1 por padrao)
+
+**Padroes reconhecidos:**
+
+| Padrao (keyword no `name`) | Wireframe |
+|-|-|
+| `sidebar` | Retangulo vertical a esquerda (60px) + area principal. Sidebar com 5-6 linhas representando menu items. |
+| `bottom` / `tab bar` | Retangulo principal + barra inferior com 4-5 circulos/quadrados representando icones |
+| `tabs` / `top tabs` | Barra superior com 3-4 retangulos horizontais representando tabs + area de conteudo |
+| `breadcrumb` | Barra superior fina com setas ">" entre blocos de texto |
+| `hamburger` / `drawer` | Icone de hamburger no canto + overlay lateral |
+
+**Layout do componente:**
+```
+[---Wireframe SVG (200x140px)---]
+  Nome do Padrao (bold)
+  Descricao (muted)
+```
+
+**Responsividade:**
+- Desktop: grid 2 colunas
+- Mobile: 1 coluna
+
+**Estados:**
+- Default: fundo `bg-gray-50`, borda `border`
+- Hover: `border-blue-200` (feedback sutil)
+
+**Microcopy:**
+- Titulo da secao: "Navegacao Principal"
+- Se sem dados: "Nenhum padrao de navegacao definido."
+
+---
+
+### F.2 Wireframes e Fluxos -- Wireframes de Telas
+
+#### Componente: `WireframePreview`
+- **Entrada**: Array de `{ name, description, layout }`
+- **Saida**: Grid de wireframes esquematicos (1 por tela)
+
+**Layouts reconhecidos (keyword no `layout`):**
+
+| Keyword | Wireframe |
+|---------|-----------|
+| `sidebar` | Grid 2 colunas: barra lateral estreita + area principal |
+| `card` / `grid` | Area principal com grid de 2x2 ou 3 retangulos (cards) |
+| `list` / `table` | Area principal com linhas horizontais empilhadas |
+| `form` | Area principal com retangulos verticais (campos) + botao abaixo |
+| `map` / `mapa` | Area grande (mapa) + sidebar ou panel inferior |
+| `mobile` / `app` | Viewport estreito (telefone) com header, conteudo, footer |
+| `split` / `2 colunas` | Grid 50/50 |
+| Generico | Retangulo com header, body, footer genericos |
+
+**Layout do componente:**
+```
+[Persona Badge] [Nome da Tela] (header)
+[--- Wireframe esquematico (aspect 16:10) ---]
+  Descricao (muted, max 2 linhas)
+  Layout: "Sidebar fixa + area principal" (code, gray)
+```
+
+**Responsividade:**
+- Desktop: grid 2 colunas
+- Mobile: 1 coluna, wireframes em tamanho menor
+
+**Interacao:**
+- Hover: borda azul + shadow sutil
+- Click (futuro): poderia abrir modal com wireframe ampliado
+
+**Microcopy:**
+- Titulo: "Wireframes e Fluxos"
+- Subtitulo: "Representacao esquematica dos layouts principais"
+- Estado vazio: "Nenhum wireframe definido neste plano."
+- Label do layout: prefixo "Layout:" em cinza
+
+---
+
+### F.3 Biblioteca de Componentes -- Preview Visual
+
+#### Componente: `ComponentLibraryPreview`
+- **Entrada**: Array de `{ name, variants: [{ name, description }] }`
+- **Saida**: Secoes agrupadas com preview visual de cada variante
+
+**Renderizacao por tipo de componente:**
+
+| Tipo (keyword no grupo `name`) | Preview |
+|-|---------|
+| `button` / `botao` / `botoes` | Botoes reais renderizados com Tailwind: Primary (bg-blue-600), Secondary (border), Destructive (bg-red-500), Ghost (transparent) |
+| `badge` / `status` / `tag` | Pills coloridas: cada variante com cor diferente baseada no nome (success=verde, warning=amarelo, error=vermelho, info=azul, default=cinza) |
+| `card` | Retangulos com borda, titulo placeholder e texto placeholder |
+| `input` / `form` / `campo` | Campos de formulario: text input com label, select com opcoes, textarea |
+| `navigation` / `nav` / `menu` | Links horizontais ou verticais simulando menu |
+| `modal` / `dialog` | Retangulo overlay com header, body, footer |
+| Outro | Chip com nome da variante + descricao ao lado |
+
+**Layout do componente:**
+```
+Nome do Grupo (bold)
+[---Area de preview com fundo bg-gray-50---]
+  [Preview visual] [Nome] [Descricao]
+  [Preview visual] [Nome] [Descricao]
+  ...
+```
+
+**Responsividade:**
+- Desktop: preview e texto lado a lado
+- Mobile: preview acima, texto abaixo
+
+**Microcopy:**
+- Titulo: "Biblioteca de Componentes"
+- Subtitulo: "Preview das variantes de UI definidas para o projeto"
+- Estado vazio: "Nenhum componente definido neste plano."
+
+---
+
+### F.4 Acessibilidade (WCAG 2.2 AA)
+
+| Requisito | Implementacao |
+|-----------|---------------|
+| Contraste | Wireframes usam `gray-300` sobre `white` (fundo) -- ratio 2.6:1 aceitavel para decorativo. Labels usam cores com ratio >= 4.5:1 |
+| Teclado | Wireframes nao sao interativos (decorativos). Labels sao texto estatico |
+| Screen reader | `aria-hidden="true"` nos SVGs/divs decorativos dos wireframes. Texto descritivo permanece legivel pelo SR |
+| Alt text | SVGs tem `role="img"` + `aria-label` descrevendo o wireframe (ex: "Wireframe esquematico de dashboard com sidebar e grid de cards") |
+| Reducao de movimento | Hover animations usam `transition-colors` (seguro). Sem animacoes complexas |
+
+---
+
+## G. Mockups
+
+### Lista de Arquivos
+
+| Arquivo | Proposito |
+|---------|-----------|
+| `mockups/project/phase-2-planning/ux-visual-sections/index.html` | Hub de navegacao entre os 3 mockups |
+| `mockups/project/phase-2-planning/ux-visual-sections/01-navigation-preview.html` | Preview visual da secao Navegacao Principal |
+| `mockups/project/phase-2-planning/ux-visual-sections/02-wireframe-preview.html` | Preview visual da secao Wireframes e Fluxos |
+| `mockups/project/phase-2-planning/ux-visual-sections/03-component-library-preview.html` | Preview visual da secao Biblioteca de Componentes |
+
+### Estados Simulados
+- Default: wireframes com dados do JSON de exemplo (App Delivery)
+- Estado vazio: toggle para simular JSON sem dados em cada secao
+- Responsivo: redimensionar browser para ver comportamento mobile
+
+---
+
+## H. Checklist Final
+
+- [x] Persona tem JTBD e dores claras
+- [x] Jornada cobre happy path e edge cases
+- [x] Cada secao visual tem todos os estados especificados
+- [x] Microcopy completa e acionavel
+- [x] Mockups demonstram as interacoes-chave
+- [x] Checklist de acessibilidade completo
+- [x] Premissas claramente marcadas
+- [x] Proximos passos de validacao definidos
+
+---
+
+## I. Proximos Passos
+
+1. **Validar hipoteses H1-H3** com 3-5 usuarios (teste de 5 segundos nos wireframes)
+2. **Implementar componentes React** seguindo esta spec:
+   - `NavigationPreview` -- secao de navegacao
+   - `WireframePreview` -- secao de wireframes
+   - `ComponentLibraryPreview` -- secao de biblioteca
+3. **Enriquecer o prompt da IA** (`UX_PLAN_SYSTEM_PROMPT`) para gerar `layout` mais estruturado
+4. **Testar com JSONs reais** de 5 projetos diferentes para validar cobertura de padroes
+5. **Medir metricas**: tempo de revisao do UX Plan antes vs depois
+
+---
+
+**Proximo passo sugerido:** Implementar o componente `WireframePreview` primeiro, pois e o de maior impacto visual e valida a abordagem de parsing do campo `layout`.

--- a/mockups/project/phase-2-planning/ux-visual-sections/01-navigation-preview.html
+++ b/mockups/project/phase-2-planning/ux-visual-sections/01-navigation-preview.html
@@ -1,0 +1,538 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Navegacao Principal - Visual Preview | True Coding</title>
+  <link rel="stylesheet" href="../../../css/tokens.css">
+  <style>
+    body {
+      background: var(--color-bg-secondary);
+      padding: var(--space-6);
+    }
+    .container {
+      max-width: 768px;
+      margin: 0 auto;
+    }
+    .back-link {
+      display: inline-block;
+      margin-bottom: var(--space-4);
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+    }
+    .back-link:hover { color: var(--color-primary); }
+
+    /* Card wrapper matching WorkspacePanel style */
+    .plan-card {
+      background: white;
+      border: 1px solid var(--color-border);
+      border-radius: var(--border-radius-xl);
+      padding: var(--space-6);
+      margin-bottom: var(--space-6);
+    }
+    .plan-card h3 {
+      font-size: var(--font-size-lg);
+      font-weight: var(--font-weight-semibold);
+      margin-bottom: var(--space-4);
+    }
+
+    /* Navigation pattern grid */
+    .nav-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: var(--space-4);
+    }
+    @media (max-width: 640px) {
+      .nav-grid { grid-template-columns: 1fr; }
+    }
+
+    /* Individual nav pattern card */
+    .nav-pattern {
+      border: 1px solid var(--color-border);
+      border-radius: var(--border-radius-lg);
+      overflow: hidden;
+      transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+    }
+    .nav-pattern:hover {
+      border-color: var(--color-primary-light);
+      box-shadow: 0 2px 8px rgba(37, 99, 235, 0.08);
+    }
+
+    /* Wireframe area */
+    .nav-wireframe {
+      background: var(--color-bg-secondary);
+      padding: var(--space-4);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 140px;
+    }
+
+    /* Label area */
+    .nav-label {
+      padding: var(--space-3) var(--space-4);
+    }
+    .nav-label-name {
+      font-size: var(--font-size-sm);
+      font-weight: var(--font-weight-semibold);
+      color: var(--color-text-primary);
+      margin-bottom: var(--space-1);
+    }
+    .nav-label-desc {
+      font-size: var(--font-size-xs);
+      color: var(--color-text-secondary);
+      line-height: 1.5;
+    }
+
+    /* ============ WIREFRAME STYLES ============ */
+
+    /* Sidebar wireframe */
+    .wf-sidebar {
+      display: grid;
+      grid-template-columns: 56px 1fr;
+      gap: 2px;
+      width: 100%;
+      max-width: 240px;
+      height: 120px;
+      border: 2px solid var(--color-gray-300);
+      border-radius: var(--border-radius-md);
+      overflow: hidden;
+      background: var(--color-gray-300);
+    }
+    .wf-sidebar-left {
+      background: var(--color-gray-200);
+      padding: 8px 6px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .wf-sidebar-left .wf-logo {
+      width: 28px;
+      height: 28px;
+      background: var(--color-primary);
+      border-radius: var(--border-radius-sm);
+      margin-bottom: 4px;
+    }
+    .wf-sidebar-left .wf-menu-item {
+      height: 6px;
+      background: var(--color-gray-400);
+      border-radius: 3px;
+      width: 80%;
+    }
+    .wf-sidebar-left .wf-menu-item.active {
+      background: var(--color-primary);
+    }
+    .wf-sidebar-right {
+      background: white;
+      padding: 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .wf-sidebar-right .wf-header-line {
+      height: 8px;
+      background: var(--color-gray-200);
+      border-radius: 4px;
+      width: 60%;
+    }
+    .wf-sidebar-right .wf-content-block {
+      flex: 1;
+      background: var(--color-gray-100);
+      border-radius: var(--border-radius-sm);
+    }
+
+    /* Bottom Tab Bar wireframe */
+    .wf-bottom-tabs {
+      width: 160px;
+      height: 120px;
+      border: 2px solid var(--color-gray-300);
+      border-radius: 16px;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      background: white;
+    }
+    .wf-bottom-tabs .wf-screen {
+      flex: 1;
+      background: var(--color-gray-100);
+      margin: 8px 8px 4px 8px;
+      border-radius: var(--border-radius-sm);
+    }
+    .wf-bottom-tabs .wf-tab-bar {
+      display: flex;
+      justify-content: space-around;
+      align-items: center;
+      padding: 6px 8px 10px;
+      border-top: 1px solid var(--color-gray-200);
+    }
+    .wf-bottom-tabs .wf-tab-icon {
+      width: 20px;
+      height: 20px;
+      border-radius: 4px;
+      background: var(--color-gray-300);
+    }
+    .wf-bottom-tabs .wf-tab-icon.active {
+      background: var(--color-primary);
+    }
+
+    /* Top Tabs wireframe */
+    .wf-top-tabs {
+      width: 100%;
+      max-width: 240px;
+      height: 120px;
+      border: 2px solid var(--color-gray-300);
+      border-radius: var(--border-radius-md);
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      background: white;
+    }
+    .wf-top-tabs .wf-tab-row {
+      display: flex;
+      border-bottom: 2px solid var(--color-gray-200);
+      padding: 0 8px;
+    }
+    .wf-top-tabs .wf-tab {
+      padding: 8px 12px;
+      font-size: 9px;
+      font-weight: var(--font-weight-semibold);
+      color: var(--color-gray-400);
+      border-bottom: 2px solid transparent;
+      margin-bottom: -2px;
+    }
+    .wf-top-tabs .wf-tab.active {
+      color: var(--color-primary);
+      border-bottom-color: var(--color-primary);
+    }
+    .wf-top-tabs .wf-tab-content {
+      flex: 1;
+      background: var(--color-gray-100);
+      margin: 8px;
+      border-radius: var(--border-radius-sm);
+    }
+
+    /* Breadcrumb wireframe */
+    .wf-breadcrumb-container {
+      width: 100%;
+      max-width: 240px;
+      height: 120px;
+      border: 2px solid var(--color-gray-300);
+      border-radius: var(--border-radius-md);
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      background: white;
+    }
+    .wf-breadcrumb-bar {
+      padding: 10px 12px;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      border-bottom: 1px solid var(--color-gray-200);
+    }
+    .wf-breadcrumb-item {
+      font-size: 9px;
+      color: var(--color-primary);
+      font-weight: var(--font-weight-medium);
+    }
+    .wf-breadcrumb-item.current {
+      color: var(--color-text-primary);
+      font-weight: var(--font-weight-semibold);
+    }
+    .wf-breadcrumb-sep {
+      font-size: 9px;
+      color: var(--color-gray-400);
+    }
+    .wf-breadcrumb-content {
+      flex: 1;
+      background: var(--color-gray-100);
+      margin: 8px;
+      border-radius: var(--border-radius-sm);
+    }
+
+    /* Comparison section */
+    .comparison {
+      margin-top: var(--space-8);
+    }
+    .comparison h3 {
+      font-size: var(--font-size-lg);
+      font-weight: var(--font-weight-semibold);
+      margin-bottom: var(--space-4);
+    }
+    .comparison-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: var(--space-4);
+    }
+    @media (max-width: 640px) {
+      .comparison-grid { grid-template-columns: 1fr; }
+    }
+    .comparison-card {
+      border: 1px solid var(--color-border);
+      border-radius: var(--border-radius-lg);
+      padding: var(--space-4);
+      background: white;
+    }
+    .comparison-card.before {
+      border-color: var(--color-error);
+      border-style: dashed;
+    }
+    .comparison-card.after {
+      border-color: var(--color-success);
+    }
+    .comparison-label {
+      font-size: var(--font-size-xs);
+      font-weight: var(--font-weight-semibold);
+      text-transform: uppercase;
+      margin-bottom: var(--space-3);
+    }
+    .comparison-card.before .comparison-label { color: var(--color-error); }
+    .comparison-card.after .comparison-label { color: var(--color-success); }
+
+    /* Text-only representation (before) */
+    .text-only-item {
+      padding: var(--space-3);
+      background: var(--color-bg-secondary);
+      border-radius: var(--border-radius-sm);
+      margin-bottom: var(--space-2);
+    }
+    .text-only-item strong {
+      font-size: var(--font-size-sm);
+      display: block;
+      margin-bottom: var(--space-1);
+    }
+    .text-only-item span {
+      font-size: var(--font-size-xs);
+      color: var(--color-text-secondary);
+    }
+
+    /* Implementation hint */
+    .impl-hint {
+      margin-top: var(--space-6);
+      padding: var(--space-4);
+      background: var(--color-bg-secondary);
+      border-radius: var(--border-radius-md);
+      border-left: 4px solid var(--color-primary);
+      font-size: var(--font-size-sm);
+      line-height: 1.6;
+    }
+    .impl-hint strong {
+      display: block;
+      margin-bottom: var(--space-2);
+    }
+    .impl-hint code {
+      background: var(--color-bg-tertiary);
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: var(--font-size-xs);
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <a href="index.html" class="back-link">&#8592; Voltar ao indice</a>
+
+    <!-- ============================================ -->
+    <!-- SECAO: ANTES vs DEPOIS (Comparacao) -->
+    <!-- ============================================ -->
+    <div class="comparison">
+      <h3>Antes vs Depois</h3>
+      <div class="comparison-grid">
+        <!-- ANTES: Apenas texto -->
+        <div class="comparison-card before">
+          <div class="comparison-label">Antes (somente texto)</div>
+          <div class="text-only-item">
+            <strong>Sidebar Fixa (Desktop)</strong>
+            <span>Sempre visivel, colapsavel, com icones + labels. Highlight na pagina ativa.</span>
+          </div>
+          <div class="text-only-item">
+            <strong>Bottom Tab Bar (Mobile)</strong>
+            <span>5 tabs principais: Dashboard, Pedidos, Cardapio, Entregas, Perfil. Icones grandes.</span>
+          </div>
+          <div class="text-only-item">
+            <strong>Breadcrumbs</strong>
+            <span>Contexto hierarquico em paginas profundas. Ex: "Pedidos > #1234 > Detalhes"</span>
+          </div>
+        </div>
+
+        <!-- DEPOIS: Com wireframe visual -->
+        <div class="comparison-card after">
+          <div class="comparison-label">Depois (com preview visual)</div>
+          <!-- Mini preview of the new approach -->
+          <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px;">
+            <!-- Mini sidebar -->
+            <div style="text-align: center;">
+              <div style="border: 1px solid var(--color-gray-300); border-radius: 4px; overflow: hidden; height: 60px; display: grid; grid-template-columns: 14px 1fr; gap: 1px; background: var(--color-gray-200);">
+                <div style="background: var(--color-gray-200); padding: 4px 2px;">
+                  <div style="width: 8px; height: 8px; background: var(--color-primary); border-radius: 2px; margin-bottom: 3px;"></div>
+                  <div style="width: 8px; height: 2px; background: var(--color-gray-400); border-radius: 1px; margin-bottom: 2px;"></div>
+                  <div style="width: 8px; height: 2px; background: var(--color-primary); border-radius: 1px; margin-bottom: 2px;"></div>
+                  <div style="width: 8px; height: 2px; background: var(--color-gray-400); border-radius: 1px;"></div>
+                </div>
+                <div style="background: white;"></div>
+              </div>
+              <div style="font-size: 9px; color: var(--color-text-tertiary); margin-top: 4px;">Sidebar</div>
+            </div>
+            <!-- Mini bottom tabs -->
+            <div style="text-align: center;">
+              <div style="border: 1px solid var(--color-gray-300); border-radius: 8px; overflow: hidden; height: 60px; display: flex; flex-direction: column; background: white;">
+                <div style="flex: 1; background: var(--color-gray-100); margin: 4px 4px 2px 4px; border-radius: 2px;"></div>
+                <div style="display: flex; justify-content: space-around; padding: 4px; border-top: 1px solid var(--color-gray-200);">
+                  <div style="width: 8px; height: 8px; background: var(--color-primary); border-radius: 2px;"></div>
+                  <div style="width: 8px; height: 8px; background: var(--color-gray-300); border-radius: 2px;"></div>
+                  <div style="width: 8px; height: 8px; background: var(--color-gray-300); border-radius: 2px;"></div>
+                  <div style="width: 8px; height: 8px; background: var(--color-gray-300); border-radius: 2px;"></div>
+                </div>
+              </div>
+              <div style="font-size: 9px; color: var(--color-text-tertiary); margin-top: 4px;">Bottom Bar</div>
+            </div>
+            <!-- Mini breadcrumb -->
+            <div style="text-align: center;">
+              <div style="border: 1px solid var(--color-gray-300); border-radius: 4px; overflow: hidden; height: 60px; display: flex; flex-direction: column; background: white;">
+                <div style="padding: 4px 6px; display: flex; align-items: center; gap: 2px; border-bottom: 1px solid var(--color-gray-200);">
+                  <div style="width: 16px; height: 4px; background: var(--color-primary); border-radius: 2px;"></div>
+                  <span style="font-size: 7px; color: var(--color-gray-400);">></span>
+                  <div style="width: 12px; height: 4px; background: var(--color-gray-700); border-radius: 2px;"></div>
+                </div>
+                <div style="flex: 1; background: var(--color-gray-100); margin: 4px; border-radius: 2px;"></div>
+              </div>
+              <div style="font-size: 9px; color: var(--color-text-tertiary); margin-top: 4px;">Breadcrumb</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================ -->
+    <!-- SECAO: COMO FICARIA NO UX PLAN -->
+    <!-- ============================================ -->
+    <div style="margin-top: var(--space-8);">
+      <h3 style="font-size: var(--font-size-lg); font-weight: var(--font-weight-semibold); margin-bottom: var(--space-2);">
+        Como ficaria no UX Plan
+      </h3>
+      <p style="font-size: var(--font-size-sm); color: var(--color-text-secondary); margin-bottom: var(--space-4);">
+        Dentro do card "Arquitetura de Informacao", a sub-secao Navegacao Principal
+        substituiria os blocos de texto por wireframes esquematicos.
+      </p>
+    </div>
+
+    <!-- Card no estilo do WorkspacePanel -->
+    <div class="plan-card">
+      <h3>Navegacao Principal</h3>
+
+      <div class="nav-grid">
+        <!-- Pattern 1: Sidebar Fixa -->
+        <div class="nav-pattern">
+          <div class="nav-wireframe" aria-hidden="true">
+            <!-- Sidebar wireframe using pure HTML/CSS -->
+            <div class="wf-sidebar">
+              <div class="wf-sidebar-left">
+                <div class="wf-logo"></div>
+                <div class="wf-menu-item"></div>
+                <div class="wf-menu-item active"></div>
+                <div class="wf-menu-item"></div>
+                <div class="wf-menu-item"></div>
+                <div class="wf-menu-item"></div>
+              </div>
+              <div class="wf-sidebar-right">
+                <div class="wf-header-line"></div>
+                <div class="wf-content-block"></div>
+              </div>
+            </div>
+          </div>
+          <div class="nav-label">
+            <div class="nav-label-name">Sidebar Fixa (Desktop)</div>
+            <div class="nav-label-desc">Sempre visivel, colapsavel, com icones + labels. Highlight na pagina ativa.</div>
+          </div>
+        </div>
+
+        <!-- Pattern 2: Bottom Tab Bar -->
+        <div class="nav-pattern">
+          <div class="nav-wireframe" aria-hidden="true">
+            <div class="wf-bottom-tabs">
+              <div class="wf-screen"></div>
+              <div class="wf-tab-bar">
+                <div class="wf-tab-icon active"></div>
+                <div class="wf-tab-icon"></div>
+                <div class="wf-tab-icon"></div>
+                <div class="wf-tab-icon"></div>
+                <div class="wf-tab-icon"></div>
+              </div>
+            </div>
+          </div>
+          <div class="nav-label">
+            <div class="nav-label-name">Bottom Tab Bar (Mobile)</div>
+            <div class="nav-label-desc">5 tabs principais: Dashboard, Pedidos, Cardapio, Entregas, Perfil. Icones grandes, facil toque com polegar.</div>
+          </div>
+        </div>
+
+        <!-- Pattern 3: Top Tabs -->
+        <div class="nav-pattern">
+          <div class="nav-wireframe" aria-hidden="true">
+            <div class="wf-top-tabs">
+              <div class="wf-tab-row">
+                <div class="wf-tab active">Geral</div>
+                <div class="wf-tab">Pedidos</div>
+                <div class="wf-tab">Config</div>
+              </div>
+              <div class="wf-tab-content"></div>
+            </div>
+          </div>
+          <div class="nav-label">
+            <div class="nav-label-name">Top Tabs</div>
+            <div class="nav-label-desc">Navegacao por abas horizontais para subdivisoes de conteudo dentro de uma mesma pagina.</div>
+          </div>
+        </div>
+
+        <!-- Pattern 4: Breadcrumbs -->
+        <div class="nav-pattern">
+          <div class="nav-wireframe" aria-hidden="true">
+            <div class="wf-breadcrumb-container">
+              <div class="wf-breadcrumb-bar">
+                <span class="wf-breadcrumb-item">Pedidos</span>
+                <span class="wf-breadcrumb-sep">></span>
+                <span class="wf-breadcrumb-item">#1234</span>
+                <span class="wf-breadcrumb-sep">></span>
+                <span class="wf-breadcrumb-item current">Detalhes</span>
+              </div>
+              <div class="wf-breadcrumb-content"></div>
+            </div>
+          </div>
+          <div class="nav-label">
+            <div class="nav-label-name">Breadcrumbs</div>
+            <div class="nav-label-desc">Contexto hierarquico em paginas profundas. Ex: "Pedidos > #1234 > Detalhes"</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================ -->
+    <!-- DICAS DE IMPLEMENTACAO -->
+    <!-- ============================================ -->
+    <div class="impl-hint">
+      <strong>Dicas de Implementacao em React/Tailwind</strong>
+      <p>
+        <strong>Componente:</strong> <code>NavigationPreview</code><br>
+        <strong>Entrada:</strong> <code>navigation: Array&lt;{"{"} name: string, description: string {"}"}&gt;</code><br>
+        <strong>Logica de deteccao:</strong> Fazer <code>name.toLowerCase()</code> e testar keywords:
+      </p>
+      <ul style="font-size: var(--font-size-xs); margin-top: var(--space-2); padding-left: var(--space-5); line-height: 2;">
+        <li><code>sidebar</code> -> Wireframe de sidebar com menu lateral</li>
+        <li><code>bottom</code> ou <code>tab bar</code> -> Wireframe de bottom tabs (formato mobile)</li>
+        <li><code>tabs</code> ou <code>top</code> -> Wireframe de tabs horizontais</li>
+        <li><code>breadcrumb</code> -> Wireframe de barra de breadcrumbs</li>
+        <li><code>hamburger</code> ou <code>drawer</code> -> Wireframe de menu hamburger</li>
+        <li>Default -> Texto descritivo com icone generico</li>
+      </ul>
+      <p style="margin-top: var(--space-3);">
+        <strong>Tailwind classes chave:</strong>
+        <code>bg-gray-100</code>, <code>bg-gray-200</code>, <code>bg-gray-300</code> para zonas de wireframe.
+        <code>bg-blue-600</code> para elementos ativos/highlight.
+        <code>rounded-md</code> ou <code>rounded-lg</code> para bordas.
+        Grid com <code>grid grid-cols-2 gap-4</code> em desktop, <code>grid-cols-1</code> em mobile.
+      </p>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/mockups/project/phase-2-planning/ux-visual-sections/02-wireframe-preview.html
+++ b/mockups/project/phase-2-planning/ux-visual-sections/02-wireframe-preview.html
@@ -1,0 +1,1004 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Wireframes e Fluxos - Visual Preview | True Coding</title>
+  <link rel="stylesheet" href="../../../css/tokens.css">
+  <style>
+    body {
+      background: var(--color-bg-secondary);
+      padding: var(--space-6);
+    }
+    .container {
+      max-width: 768px;
+      margin: 0 auto;
+    }
+    .back-link {
+      display: inline-block;
+      margin-bottom: var(--space-4);
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+    }
+    .back-link:hover { color: var(--color-primary); }
+
+    .plan-card {
+      background: white;
+      border: 1px solid var(--color-border);
+      border-radius: var(--border-radius-xl);
+      padding: var(--space-6);
+      margin-bottom: var(--space-6);
+    }
+    .plan-card h3 {
+      font-size: var(--font-size-lg);
+      font-weight: var(--font-weight-semibold);
+      margin-bottom: var(--space-1);
+    }
+    .plan-card .subtitle {
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+      margin-bottom: var(--space-5);
+    }
+
+    /* Wireframe grid */
+    .wf-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: var(--space-4);
+    }
+    @media (max-width: 640px) {
+      .wf-grid { grid-template-columns: 1fr; }
+    }
+
+    /* Individual wireframe card */
+    .wf-card {
+      border: 1px solid var(--color-border);
+      border-radius: var(--border-radius-lg);
+      overflow: hidden;
+      transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+    }
+    .wf-card:hover {
+      border-color: var(--color-primary-light);
+      box-shadow: 0 2px 8px rgba(37, 99, 235, 0.08);
+    }
+
+    /* Wireframe header */
+    .wf-card-header {
+      padding: var(--space-2) var(--space-3);
+      background: var(--color-bg-secondary);
+      border-bottom: 1px solid var(--color-border);
+      display: flex;
+      align-items: center;
+      gap: var(--space-2);
+    }
+    .wf-persona-badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: var(--border-radius-full);
+      font-size: 10px;
+      font-weight: var(--font-weight-medium);
+    }
+    .wf-persona-badge.restaurant {
+      background: var(--color-primary-light);
+      color: var(--color-primary);
+    }
+    .wf-persona-badge.customer {
+      background: var(--color-warning-light);
+      color: #92400e;
+    }
+    .wf-persona-badge.driver {
+      background: var(--color-success-light);
+      color: #065f46;
+    }
+    .wf-card-name {
+      font-size: var(--font-size-sm);
+      font-weight: var(--font-weight-semibold);
+    }
+
+    /* Wireframe drawing area */
+    .wf-drawing {
+      background: var(--color-bg-secondary);
+      padding: var(--space-3);
+      min-height: 160px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    /* Wireframe footer */
+    .wf-card-footer {
+      padding: var(--space-3);
+      border-top: 1px solid var(--color-border);
+    }
+    .wf-card-desc {
+      font-size: var(--font-size-xs);
+      color: var(--color-text-secondary);
+      line-height: 1.5;
+      margin-bottom: var(--space-2);
+    }
+    .wf-card-layout {
+      font-size: var(--font-size-xs);
+      color: var(--color-text-tertiary);
+      font-family: monospace;
+      background: var(--color-bg-secondary);
+      padding: 4px 8px;
+      border-radius: var(--border-radius-sm);
+      display: inline-block;
+    }
+
+    /* ============ WIREFRAME DRAWINGS ============ */
+
+    /* Dashboard: sidebar + grid cards */
+    .wf-dashboard {
+      width: 100%;
+      max-width: 280px;
+      height: 140px;
+      border: 2px solid var(--color-gray-300);
+      border-radius: var(--border-radius-md);
+      display: grid;
+      grid-template-columns: 48px 1fr;
+      overflow: hidden;
+      background: white;
+    }
+    .wf-dash-sidebar {
+      background: var(--color-gray-200);
+      padding: 6px 4px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .wf-dash-sidebar .logo {
+      width: 20px;
+      height: 20px;
+      background: var(--color-primary);
+      border-radius: 3px;
+      margin: 0 auto 4px;
+    }
+    .wf-dash-sidebar .item {
+      height: 4px;
+      background: var(--color-gray-400);
+      border-radius: 2px;
+      margin: 0 2px;
+    }
+    .wf-dash-sidebar .item.active {
+      background: var(--color-primary);
+    }
+    .wf-dash-main {
+      padding: 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .wf-dash-header {
+      height: 6px;
+      width: 50%;
+      background: var(--color-gray-300);
+      border-radius: 3px;
+    }
+    .wf-dash-metrics {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 4px;
+    }
+    .wf-dash-metric {
+      background: var(--color-gray-100);
+      border-radius: 3px;
+      padding: 4px;
+      text-align: center;
+    }
+    .wf-dash-metric .number {
+      font-size: 10px;
+      font-weight: var(--font-weight-bold);
+      color: var(--color-gray-500);
+    }
+    .wf-dash-metric .label {
+      font-size: 6px;
+      color: var(--color-gray-400);
+    }
+    .wf-dash-list {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+    }
+    .wf-dash-list-item {
+      height: 14px;
+      background: var(--color-gray-100);
+      border-radius: 3px;
+      display: flex;
+      align-items: center;
+      padding: 0 6px;
+      gap: 4px;
+    }
+    .wf-dash-list-item .dot {
+      width: 4px;
+      height: 4px;
+      border-radius: 50%;
+    }
+    .wf-dash-list-item .dot.warning { background: var(--color-warning); }
+    .wf-dash-list-item .dot.success { background: var(--color-success); }
+    .wf-dash-list-item .dot.error { background: var(--color-error); }
+    .wf-dash-list-item .line {
+      height: 3px;
+      flex: 1;
+      background: var(--color-gray-300);
+      border-radius: 2px;
+    }
+
+    /* Order Detail: sidebar-less, 2 col */
+    .wf-order-detail {
+      width: 100%;
+      max-width: 280px;
+      height: 140px;
+      border: 2px solid var(--color-gray-300);
+      border-radius: var(--border-radius-md);
+      overflow: hidden;
+      background: white;
+      display: flex;
+      flex-direction: column;
+    }
+    .wf-order-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 6px 10px;
+      border-bottom: 1px solid var(--color-gray-200);
+    }
+    .wf-order-id {
+      font-size: 9px;
+      font-weight: var(--font-weight-bold);
+      color: var(--color-text-primary);
+    }
+    .wf-order-status {
+      font-size: 8px;
+      padding: 2px 8px;
+      border-radius: var(--border-radius-full);
+      font-weight: var(--font-weight-medium);
+    }
+    .wf-order-status.preparing {
+      background: var(--color-warning-light);
+      color: #92400e;
+    }
+    .wf-order-body {
+      flex: 1;
+      display: grid;
+      grid-template-columns: 1.5fr 1fr;
+      gap: 6px;
+      padding: 8px 10px;
+    }
+    .wf-order-items {
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+    }
+    .wf-order-items .line {
+      height: 4px;
+      background: var(--color-gray-200);
+      border-radius: 2px;
+    }
+    .wf-order-items .line.bold {
+      background: var(--color-gray-400);
+      height: 5px;
+      margin-top: 4px;
+      width: 60%;
+    }
+    .wf-order-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+    }
+    .wf-order-btn {
+      height: 14px;
+      border-radius: 3px;
+      border: none;
+    }
+    .wf-order-btn.accept { background: var(--color-success); }
+    .wf-order-btn.reject { background: var(--color-error); }
+    .wf-order-btn.contact {
+      background: white;
+      border: 1px solid var(--color-gray-300);
+    }
+    .wf-order-btn.assign { background: var(--color-primary); }
+
+    /* Menu Editor: list layout */
+    .wf-menu-editor {
+      width: 100%;
+      max-width: 280px;
+      height: 140px;
+      border: 2px solid var(--color-gray-300);
+      border-radius: var(--border-radius-md);
+      overflow: hidden;
+      background: white;
+      display: flex;
+      flex-direction: column;
+    }
+    .wf-menu-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 6px 10px;
+      border-bottom: 1px solid var(--color-gray-200);
+    }
+    .wf-menu-title {
+      font-size: 9px;
+      font-weight: var(--font-weight-bold);
+    }
+    .wf-menu-add-btn {
+      font-size: 8px;
+      padding: 2px 8px;
+      background: var(--color-primary);
+      color: white;
+      border-radius: 3px;
+      border: none;
+    }
+    .wf-menu-category {
+      font-size: 7px;
+      color: var(--color-text-tertiary);
+      text-transform: uppercase;
+      padding: 4px 10px 2px;
+      font-weight: var(--font-weight-semibold);
+    }
+    .wf-menu-list {
+      flex: 1;
+      padding: 0 10px 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+    }
+    .wf-menu-item {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 4px 6px;
+      background: var(--color-gray-100);
+      border-radius: 3px;
+    }
+    .wf-menu-item .name {
+      font-size: 8px;
+      font-weight: var(--font-weight-semibold);
+    }
+    .wf-menu-item .price {
+      font-size: 7px;
+      color: var(--color-success);
+    }
+    .wf-menu-item.unavailable {
+      opacity: 0.4;
+    }
+    .wf-menu-item .actions {
+      display: flex;
+      gap: 2px;
+    }
+    .wf-menu-item .action-btn {
+      width: 16px;
+      height: 10px;
+      border-radius: 2px;
+      border: 1px solid var(--color-gray-300);
+      background: white;
+    }
+
+    /* Mobile Public Menu */
+    .wf-public-menu {
+      width: 140px;
+      height: 140px;
+      border: 2px solid var(--color-gray-300);
+      border-radius: 16px;
+      overflow: hidden;
+      background: white;
+      display: flex;
+      flex-direction: column;
+    }
+    .wf-pub-header {
+      background: var(--color-primary);
+      padding: 6px;
+      text-align: center;
+    }
+    .wf-pub-header .name {
+      font-size: 8px;
+      font-weight: var(--font-weight-bold);
+      color: white;
+    }
+    .wf-pub-header .status {
+      font-size: 6px;
+      color: rgba(255,255,255,0.7);
+    }
+    .wf-pub-tabs {
+      display: flex;
+      gap: 4px;
+      padding: 4px 6px;
+      border-bottom: 1px solid var(--color-gray-200);
+    }
+    .wf-pub-tab {
+      font-size: 7px;
+      padding: 2px 6px;
+      border-radius: var(--border-radius-full);
+    }
+    .wf-pub-tab.active {
+      background: var(--color-primary);
+      color: white;
+    }
+    .wf-pub-tab.inactive {
+      background: var(--color-gray-100);
+      color: var(--color-gray-500);
+    }
+    .wf-pub-items {
+      flex: 1;
+      padding: 4px 6px;
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+    }
+    .wf-pub-item {
+      display: flex;
+      gap: 4px;
+      align-items: center;
+    }
+    .wf-pub-item .thumb {
+      width: 20px;
+      height: 20px;
+      background: var(--color-gray-100);
+      border-radius: 3px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 10px;
+    }
+    .wf-pub-item .info {
+      flex: 1;
+    }
+    .wf-pub-item .info .name {
+      font-size: 7px;
+      font-weight: var(--font-weight-semibold);
+    }
+    .wf-pub-item .info .price {
+      font-size: 6px;
+      color: var(--color-success);
+    }
+    .wf-pub-item .add-btn {
+      width: 14px;
+      height: 14px;
+      background: var(--color-primary);
+      color: white;
+      border-radius: 50%;
+      font-size: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border: none;
+    }
+    .wf-pub-cart {
+      background: var(--color-primary);
+      padding: 4px 6px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .wf-pub-cart .total {
+      font-size: 7px;
+      color: white;
+      font-weight: var(--font-weight-bold);
+    }
+    .wf-pub-cart .cart-btn {
+      font-size: 6px;
+      padding: 2px 6px;
+      background: white;
+      color: var(--color-primary);
+      border-radius: 3px;
+      border: none;
+      font-weight: var(--font-weight-semibold);
+    }
+
+    /* Delivery Offer (Mobile) */
+    .wf-delivery-offer {
+      width: 140px;
+      height: 140px;
+      border: 2px solid var(--color-gray-300);
+      border-radius: 16px;
+      overflow: hidden;
+      background: white;
+      display: flex;
+      flex-direction: column;
+    }
+    .wf-del-header {
+      background: var(--color-success);
+      padding: 6px;
+      text-align: center;
+    }
+    .wf-del-header .label {
+      font-size: 6px;
+      color: rgba(255,255,255,0.7);
+      text-transform: uppercase;
+    }
+    .wf-del-header .amount {
+      font-size: 14px;
+      font-weight: var(--font-weight-bold);
+      color: white;
+    }
+    .wf-del-header .timer {
+      font-size: 6px;
+      color: rgba(255,255,255,0.7);
+    }
+    .wf-del-body {
+      flex: 1;
+      padding: 6px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .wf-del-info {
+      display: flex;
+      justify-content: space-between;
+    }
+    .wf-del-info .item-label {
+      font-size: 6px;
+      color: var(--color-text-tertiary);
+    }
+    .wf-del-info .item-value {
+      font-size: 7px;
+      font-weight: var(--font-weight-semibold);
+    }
+    .wf-del-address {
+      padding: 4px;
+      background: var(--color-gray-100);
+      border-radius: 3px;
+      font-size: 6px;
+      color: var(--color-text-secondary);
+    }
+    .wf-del-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+      margin-top: auto;
+    }
+    .wf-del-accept {
+      padding: 5px;
+      background: var(--color-success);
+      color: white;
+      border: none;
+      border-radius: 4px;
+      font-size: 8px;
+      font-weight: var(--font-weight-bold);
+      text-align: center;
+    }
+    .wf-del-reject {
+      padding: 3px;
+      background: transparent;
+      color: var(--color-text-secondary);
+      border: 1px solid var(--color-gray-300);
+      border-radius: 4px;
+      font-size: 7px;
+      text-align: center;
+    }
+
+    /* Comparison */
+    .comparison {
+      margin-top: var(--space-8);
+    }
+    .comparison h3 {
+      font-size: var(--font-size-lg);
+      font-weight: var(--font-weight-semibold);
+      margin-bottom: var(--space-4);
+    }
+    .comparison-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: var(--space-4);
+    }
+    @media (max-width: 640px) {
+      .comparison-grid { grid-template-columns: 1fr; }
+    }
+    .comparison-card {
+      border: 1px solid var(--color-border);
+      border-radius: var(--border-radius-lg);
+      padding: var(--space-4);
+      background: white;
+    }
+    .comparison-card.before {
+      border-color: var(--color-error);
+      border-style: dashed;
+    }
+    .comparison-card.after {
+      border-color: var(--color-success);
+    }
+    .comparison-label {
+      font-size: var(--font-size-xs);
+      font-weight: var(--font-weight-semibold);
+      text-transform: uppercase;
+      margin-bottom: var(--space-3);
+    }
+    .comparison-card.before .comparison-label { color: var(--color-error); }
+    .comparison-card.after .comparison-label { color: var(--color-success); }
+
+    .text-only-wf {
+      padding: var(--space-3);
+      background: var(--color-bg-secondary);
+      border-radius: var(--border-radius-sm);
+      margin-bottom: var(--space-2);
+    }
+    .text-only-wf strong {
+      font-size: var(--font-size-sm);
+      display: block;
+      margin-bottom: var(--space-1);
+    }
+    .text-only-wf .desc {
+      font-size: var(--font-size-xs);
+      color: var(--color-text-secondary);
+      margin-bottom: var(--space-1);
+    }
+    .text-only-wf .layout {
+      font-size: var(--font-size-xs);
+      color: var(--color-text-tertiary);
+      font-style: italic;
+    }
+
+    /* Implementation hint */
+    .impl-hint {
+      margin-top: var(--space-6);
+      padding: var(--space-4);
+      background: var(--color-bg-secondary);
+      border-radius: var(--border-radius-md);
+      border-left: 4px solid var(--color-primary);
+      font-size: var(--font-size-sm);
+      line-height: 1.6;
+    }
+    .impl-hint strong {
+      display: block;
+      margin-bottom: var(--space-2);
+    }
+    .impl-hint code {
+      background: var(--color-bg-tertiary);
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: var(--font-size-xs);
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <a href="index.html" class="back-link">&#8592; Voltar ao indice</a>
+
+    <!-- ============================================ -->
+    <!-- ANTES vs DEPOIS -->
+    <!-- ============================================ -->
+    <div class="comparison">
+      <h3>Antes vs Depois</h3>
+      <div class="comparison-grid">
+        <div class="comparison-card before">
+          <div class="comparison-label">Antes (somente texto)</div>
+          <div class="text-only-wf">
+            <strong>Dashboard</strong>
+            <div class="desc">Visao geral com metricas e pedidos ativos</div>
+            <div class="layout">Sidebar fixa + area principal com cards de metricas e lista de pedidos</div>
+          </div>
+          <div class="text-only-wf">
+            <strong>Detalhes do Pedido</strong>
+            <div class="desc">Itens, cliente, endereco, acoes</div>
+            <div class="layout">Sidebar fixa + layout de 2 colunas</div>
+          </div>
+        </div>
+
+        <div class="comparison-card after">
+          <div class="comparison-label">Depois (com wireframe visual)</div>
+          <div style="display: flex; gap: 8px; justify-content: center;">
+            <!-- Mini dashboard wireframe -->
+            <div style="width: 80px; height: 50px; border: 1px solid var(--color-gray-300); border-radius: 3px; display: grid; grid-template-columns: 14px 1fr; overflow: hidden;">
+              <div style="background: var(--color-gray-200); padding: 3px 2px;">
+                <div style="width: 8px; height: 6px; background: var(--color-primary); border-radius: 1px; margin-bottom: 2px;"></div>
+                <div style="width: 8px; height: 2px; background: var(--color-gray-400); border-radius: 1px; margin-bottom: 1px;"></div>
+                <div style="width: 8px; height: 2px; background: var(--color-primary); border-radius: 1px;"></div>
+              </div>
+              <div style="padding: 3px; display: flex; flex-direction: column; gap: 2px;">
+                <div style="display: flex; gap: 2px;">
+                  <div style="flex: 1; height: 8px; background: var(--color-gray-100); border-radius: 1px;"></div>
+                  <div style="flex: 1; height: 8px; background: var(--color-gray-100); border-radius: 1px;"></div>
+                </div>
+                <div style="flex: 1; background: var(--color-gray-100); border-radius: 1px;"></div>
+              </div>
+            </div>
+            <!-- Mini order detail wireframe -->
+            <div style="width: 80px; height: 50px; border: 1px solid var(--color-gray-300); border-radius: 3px; display: flex; flex-direction: column; overflow: hidden;">
+              <div style="display: flex; justify-content: space-between; padding: 2px 4px; border-bottom: 1px solid var(--color-gray-200);">
+                <div style="width: 20px; height: 3px; background: var(--color-gray-400); border-radius: 1px;"></div>
+                <div style="width: 16px; height: 8px; background: var(--color-warning-light); border-radius: 4px;"></div>
+              </div>
+              <div style="flex: 1; display: grid; grid-template-columns: 1.5fr 1fr; gap: 2px; padding: 3px;">
+                <div style="display: flex; flex-direction: column; gap: 1px;">
+                  <div style="height: 2px; background: var(--color-gray-200); border-radius: 1px;"></div>
+                  <div style="height: 2px; background: var(--color-gray-200); border-radius: 1px;"></div>
+                  <div style="height: 2px; background: var(--color-gray-200); border-radius: 1px;"></div>
+                </div>
+                <div style="display: flex; flex-direction: column; gap: 1px;">
+                  <div style="height: 6px; background: var(--color-success); border-radius: 1px;"></div>
+                  <div style="height: 6px; background: var(--color-error); border-radius: 1px;"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div style="text-align: center; margin-top: 8px; font-size: 9px; color: var(--color-text-tertiary);">
+            Wireframes esquematicos + texto descritivo
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================ -->
+    <!-- COMO FICARIA NO UX PLAN -->
+    <!-- ============================================ -->
+    <div style="margin-top: var(--space-8);">
+      <h3 style="font-size: var(--font-size-lg); font-weight: var(--font-weight-semibold); margin-bottom: var(--space-2);">
+        Como ficaria no UX Plan
+      </h3>
+      <p style="font-size: var(--font-size-sm); color: var(--color-text-secondary); margin-bottom: var(--space-4);">
+        Cada wireframe do array <code>wireframes[]</code> gera um card com representacao
+        visual esquematica. O layout e inferido a partir do campo <code>layout</code>.
+      </p>
+    </div>
+
+    <!-- Card no estilo do WorkspacePanel -->
+    <div class="plan-card">
+      <h3>Wireframes e Fluxos</h3>
+      <p class="subtitle">Representacao esquematica dos layouts principais</p>
+
+      <div class="wf-grid">
+        <!-- Wireframe 1: Dashboard -->
+        <div class="wf-card">
+          <div class="wf-card-header">
+            <span class="wf-persona-badge restaurant">Restaurante</span>
+            <span class="wf-card-name">Dashboard</span>
+          </div>
+          <div class="wf-drawing" aria-hidden="true">
+            <div class="wf-dashboard">
+              <div class="wf-dash-sidebar">
+                <div class="logo"></div>
+                <div class="item active"></div>
+                <div class="item"></div>
+                <div class="item"></div>
+                <div class="item"></div>
+              </div>
+              <div class="wf-dash-main">
+                <div class="wf-dash-header"></div>
+                <div class="wf-dash-metrics">
+                  <div class="wf-dash-metric">
+                    <div class="number">47</div>
+                    <div class="label">Pedidos</div>
+                  </div>
+                  <div class="wf-dash-metric">
+                    <div class="number">1.8k</div>
+                    <div class="label">Receita</div>
+                  </div>
+                  <div class="wf-dash-metric">
+                    <div class="number">32m</div>
+                    <div class="label">Tempo</div>
+                  </div>
+                </div>
+                <div class="wf-dash-list">
+                  <div class="wf-dash-list-item">
+                    <div class="dot warning"></div>
+                    <div class="line"></div>
+                  </div>
+                  <div class="wf-dash-list-item">
+                    <div class="dot success"></div>
+                    <div class="line"></div>
+                  </div>
+                  <div class="wf-dash-list-item">
+                    <div class="dot error"></div>
+                    <div class="line"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="wf-card-footer">
+            <div class="wf-card-desc">Visao geral com metricas do dia, pedidos ativos e grafico de vendas</div>
+            <span class="wf-card-layout">Layout: Sidebar + cards + lista</span>
+          </div>
+        </div>
+
+        <!-- Wireframe 2: Order Detail -->
+        <div class="wf-card">
+          <div class="wf-card-header">
+            <span class="wf-persona-badge restaurant">Restaurante</span>
+            <span class="wf-card-name">Detalhes do Pedido</span>
+          </div>
+          <div class="wf-drawing" aria-hidden="true">
+            <div class="wf-order-detail">
+              <div class="wf-order-header">
+                <span class="wf-order-id">PEDIDO #1234</span>
+                <span class="wf-order-status preparing">Preparando</span>
+              </div>
+              <div class="wf-order-body">
+                <div class="wf-order-items">
+                  <div class="line" style="width: 90%;"></div>
+                  <div class="line" style="width: 70%;"></div>
+                  <div class="line" style="width: 55%;"></div>
+                  <div class="line bold"></div>
+                  <div style="margin-top: auto;">
+                    <div class="line" style="width: 60%; margin-bottom: 2px;"></div>
+                    <div class="line" style="width: 80%; margin-bottom: 2px;"></div>
+                    <div class="line" style="width: 50%;"></div>
+                  </div>
+                </div>
+                <div class="wf-order-actions">
+                  <div class="wf-order-btn accept"></div>
+                  <div class="wf-order-btn reject"></div>
+                  <div class="wf-order-btn contact"></div>
+                  <div class="wf-order-btn assign"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="wf-card-footer">
+            <div class="wf-card-desc">Itens, cliente, endereco, timeline de status, acoes do pedido</div>
+            <span class="wf-card-layout">Layout: Header + 2 colunas</span>
+          </div>
+        </div>
+
+        <!-- Wireframe 3: Menu Editor -->
+        <div class="wf-card">
+          <div class="wf-card-header">
+            <span class="wf-persona-badge restaurant">Restaurante</span>
+            <span class="wf-card-name">Editor de Cardapio</span>
+          </div>
+          <div class="wf-drawing" aria-hidden="true">
+            <div class="wf-menu-editor">
+              <div class="wf-menu-header">
+                <span class="wf-menu-title">CARDAPIO</span>
+                <button class="wf-menu-add-btn">+ Novo</button>
+              </div>
+              <div class="wf-menu-category">PIZZAS</div>
+              <div class="wf-menu-list">
+                <div class="wf-menu-item">
+                  <div>
+                    <div class="name">Margherita</div>
+                    <div class="price">R$ 40</div>
+                  </div>
+                  <div class="actions">
+                    <div class="action-btn"></div>
+                    <div class="action-btn"></div>
+                  </div>
+                </div>
+                <div class="wf-menu-item unavailable">
+                  <div>
+                    <div class="name">Calabresa</div>
+                    <div class="price">R$ 45</div>
+                  </div>
+                  <div class="actions">
+                    <div class="action-btn"></div>
+                    <div class="action-btn"></div>
+                  </div>
+                </div>
+                <div class="wf-menu-item">
+                  <div>
+                    <div class="name">4 Queijos</div>
+                    <div class="price">R$ 48</div>
+                  </div>
+                  <div class="actions">
+                    <div class="action-btn"></div>
+                    <div class="action-btn"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="wf-card-footer">
+            <div class="wf-card-desc">Categorias e itens com foto, preco, disponibilidade e acoes de edicao</div>
+            <span class="wf-card-layout">Layout: Lista editavel</span>
+          </div>
+        </div>
+
+        <!-- Wireframe 4: Public Menu (Mobile) -->
+        <div class="wf-card">
+          <div class="wf-card-header">
+            <span class="wf-persona-badge customer">Cliente</span>
+            <span class="wf-card-name">Cardapio Publico (Mobile)</span>
+          </div>
+          <div class="wf-drawing" aria-hidden="true">
+            <div class="wf-public-menu">
+              <div class="wf-pub-header">
+                <div class="name">Pizzaria Bella</div>
+                <div class="status">Aberto - 30-45 min</div>
+              </div>
+              <div class="wf-pub-tabs">
+                <span class="wf-pub-tab active">Pizzas</span>
+                <span class="wf-pub-tab inactive">Bebidas</span>
+                <span class="wf-pub-tab inactive">Doces</span>
+              </div>
+              <div class="wf-pub-items">
+                <div class="wf-pub-item">
+                  <div class="thumb">&#127829;</div>
+                  <div class="info">
+                    <div class="name">Margherita</div>
+                    <div class="price">R$ 40</div>
+                  </div>
+                  <button class="add-btn">+</button>
+                </div>
+                <div class="wf-pub-item">
+                  <div class="thumb">&#127829;</div>
+                  <div class="info">
+                    <div class="name">Calabresa</div>
+                    <div class="price">R$ 45</div>
+                  </div>
+                  <button class="add-btn">+</button>
+                </div>
+              </div>
+              <div class="wf-pub-cart">
+                <div class="total">R$ 50</div>
+                <button class="cart-btn">Carrinho</button>
+              </div>
+            </div>
+          </div>
+          <div class="wf-card-footer">
+            <div class="wf-card-desc">Categorias, itens com foto e preco, carrinho flutuante</div>
+            <span class="wf-card-layout">Layout: Mobile app + tabs + lista</span>
+          </div>
+        </div>
+
+        <!-- Wireframe 5: Delivery Offer (Mobile) -->
+        <div class="wf-card">
+          <div class="wf-card-header">
+            <span class="wf-persona-badge driver">Entregador</span>
+            <span class="wf-card-name">Oferta de Entrega (Mobile)</span>
+          </div>
+          <div class="wf-drawing" aria-hidden="true">
+            <div class="wf-delivery-offer">
+              <div class="wf-del-header">
+                <div class="label">NOVA ENTREGA</div>
+                <div class="amount">R$ 8</div>
+                <div class="timer">Aceite em 30s</div>
+              </div>
+              <div class="wf-del-body">
+                <div class="wf-del-info">
+                  <div>
+                    <div class="item-label">Restaurante</div>
+                    <div class="item-value">Pizzaria Bella</div>
+                  </div>
+                  <div style="text-align: right;">
+                    <div class="item-label">Distancia</div>
+                    <div class="item-value">3.2 km</div>
+                  </div>
+                </div>
+                <div class="wf-del-address">Rua das Flores, 123 - Centro</div>
+                <div class="wf-del-actions">
+                  <div class="wf-del-accept">ACEITAR</div>
+                  <div class="wf-del-reject">Recusar</div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="wf-card-footer">
+            <div class="wf-card-desc">Card com restaurante, distancia, valor. Aceitar abre GPS, recusar volta ao home</div>
+            <span class="wf-card-layout">Layout: Mobile app + CTA</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================ -->
+    <!-- DICAS DE IMPLEMENTACAO -->
+    <!-- ============================================ -->
+    <div class="impl-hint">
+      <strong>Dicas de Implementacao em React/Tailwind</strong>
+      <p>
+        <strong>Componente:</strong> <code>WireframePreview</code><br>
+        <strong>Entrada:</strong> <code>wireframes: Array&lt;{"{"} name, description, layout {"}"}&gt;</code>
+      </p>
+      <p style="margin-top: var(--space-2);">
+        <strong>Logica de deteccao do layout:</strong> Fazer <code>layout.toLowerCase()</code> e testar keywords:
+      </p>
+      <ul style="font-size: var(--font-size-xs); margin-top: var(--space-2); padding-left: var(--space-5); line-height: 2;">
+        <li><code>sidebar</code> -> Grid 2 colunas com barra lateral estreita + area principal</li>
+        <li><code>card</code> ou <code>grid</code> -> Grid de retangulos (2x2 ou 3 colunas)</li>
+        <li><code>list</code> ou <code>table</code> -> Linhas empilhadas horizontais</li>
+        <li><code>form</code> -> Retangulos verticais (campos) + botao</li>
+        <li><code>map</code> ou <code>mapa</code> -> Area grande + sidebar/panel</li>
+        <li><code>mobile</code> ou <code>app</code> -> Viewport de telefone (140px wide, border-radius 16px)</li>
+        <li>Default -> Header + body generico</li>
+      </ul>
+      <p style="margin-top: var(--space-3);">
+        <strong>Persona badges:</strong> Se o campo <code>wireframes</code> nao tem persona,
+        inferir pela keyword no <code>name</code> ou omitir o badge.
+        Para adicionar persona, enriquecer o JSON adicionando campo <code>persona?: string</code> no prompt.
+      </p>
+    </div>
+  </div>
+</body>
+</html>

--- a/mockups/project/phase-2-planning/ux-visual-sections/03-component-library-preview.html
+++ b/mockups/project/phase-2-planning/ux-visual-sections/03-component-library-preview.html
@@ -1,0 +1,726 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Biblioteca de Componentes - Visual Preview | True Coding</title>
+  <link rel="stylesheet" href="../../../css/tokens.css">
+  <style>
+    body {
+      background: var(--color-bg-secondary);
+      padding: var(--space-6);
+    }
+    .container {
+      max-width: 768px;
+      margin: 0 auto;
+    }
+    .back-link {
+      display: inline-block;
+      margin-bottom: var(--space-4);
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+    }
+    .back-link:hover { color: var(--color-primary); }
+
+    .plan-card {
+      background: white;
+      border: 1px solid var(--color-border);
+      border-radius: var(--border-radius-xl);
+      padding: var(--space-6);
+      margin-bottom: var(--space-6);
+    }
+    .plan-card h3 {
+      font-size: var(--font-size-lg);
+      font-weight: var(--font-weight-semibold);
+      margin-bottom: var(--space-1);
+    }
+    .plan-card .subtitle {
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+      margin-bottom: var(--space-5);
+    }
+
+    /* Component group */
+    .comp-group {
+      margin-bottom: var(--space-6);
+    }
+    .comp-group:last-child {
+      margin-bottom: 0;
+    }
+    .comp-group-name {
+      font-size: var(--font-size-sm);
+      font-weight: var(--font-weight-semibold);
+      color: var(--color-text-primary);
+      margin-bottom: var(--space-3);
+    }
+    .comp-group-preview {
+      background: var(--color-bg-secondary);
+      border-radius: var(--border-radius-md);
+      padding: var(--space-4);
+    }
+
+    /* Variant row */
+    .variant-row {
+      display: flex;
+      align-items: center;
+      gap: var(--space-4);
+      padding: var(--space-2) 0;
+    }
+    .variant-row + .variant-row {
+      border-top: 1px solid var(--color-border);
+      padding-top: var(--space-3);
+      margin-top: var(--space-2);
+    }
+    .variant-preview {
+      min-width: 140px;
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+    }
+    .variant-info {
+      flex: 1;
+    }
+    .variant-name {
+      font-size: var(--font-size-xs);
+      font-weight: var(--font-weight-semibold);
+      color: var(--color-text-primary);
+      margin-bottom: 2px;
+    }
+    .variant-desc {
+      font-size: var(--font-size-xs);
+      color: var(--color-text-secondary);
+    }
+    @media (max-width: 640px) {
+      .variant-row {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--space-2);
+      }
+      .variant-preview {
+        min-width: auto;
+      }
+    }
+
+    /* ============ BUTTON PREVIEWS ============ */
+    .preview-btn {
+      padding: 8px 16px;
+      border-radius: 6px;
+      font-size: 13px;
+      font-weight: 500;
+      cursor: default;
+      border: none;
+      white-space: nowrap;
+      font-family: var(--font-family);
+      transition: opacity var(--transition-fast);
+    }
+    .preview-btn.primary {
+      background: #2563eb;
+      color: white;
+    }
+    .preview-btn.secondary {
+      background: white;
+      color: #2563eb;
+      border: 2px solid #2563eb;
+    }
+    .preview-btn.destructive {
+      background: #ef4444;
+      color: white;
+    }
+    .preview-btn.ghost {
+      background: transparent;
+      color: #374151;
+      border: 1px solid transparent;
+    }
+    .preview-btn.ghost:hover {
+      background: var(--color-bg-tertiary);
+    }
+    .preview-btn.outline {
+      background: white;
+      color: #374151;
+      border: 1px solid #d1d5db;
+    }
+    .preview-btn.disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    /* ============ BADGE PREVIEWS ============ */
+    .preview-badge {
+      display: inline-block;
+      padding: 3px 10px;
+      border-radius: 16px;
+      font-size: 12px;
+      font-weight: 500;
+      white-space: nowrap;
+    }
+    .preview-badge.pending {
+      background: #fef3c7;
+      color: #92400e;
+    }
+    .preview-badge.preparing {
+      background: #dbeafe;
+      color: #1e40af;
+    }
+    .preview-badge.ready {
+      background: #fef3c7;
+      color: #92400e;
+    }
+    .preview-badge.delivering {
+      background: #ddd6fe;
+      color: #5b21b6;
+    }
+    .preview-badge.delivered {
+      background: #d1fae5;
+      color: #065f46;
+    }
+    .preview-badge.cancelled {
+      background: #fee2e2;
+      color: #991b1b;
+    }
+
+    /* ============ CARD PREVIEWS ============ */
+    .preview-card {
+      padding: 12px 16px;
+      border-radius: 10px;
+      background: white;
+    }
+    .preview-card.default {
+      border: 2px solid #e5e7eb;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    }
+    .preview-card.highlighted {
+      border: 2px solid #2563eb;
+      box-shadow: 0 2px 8px rgba(37,99,235,0.12);
+    }
+    .preview-card.elevated {
+      border: 1px solid #e5e7eb;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+    }
+    .preview-card-title {
+      font-size: var(--font-size-sm);
+      font-weight: var(--font-weight-semibold);
+      color: var(--color-text-primary);
+      margin-bottom: 4px;
+    }
+    .preview-card-text {
+      font-size: var(--font-size-xs);
+      color: var(--color-text-secondary);
+    }
+
+    /* ============ INPUT PREVIEWS ============ */
+    .preview-input-group {
+      width: 100%;
+      max-width: 280px;
+    }
+    .preview-input-label {
+      display: block;
+      font-size: 12px;
+      font-weight: 500;
+      margin-bottom: 4px;
+      color: var(--color-text-primary);
+    }
+    .preview-input-label.error {
+      color: #ef4444;
+    }
+    .preview-input {
+      width: 100%;
+      padding: 8px 12px;
+      border: 2px solid #e5e7eb;
+      border-radius: 6px;
+      font-size: 13px;
+      font-family: var(--font-family);
+      outline: none;
+      transition: border-color var(--transition-fast);
+      box-sizing: border-box;
+    }
+    .preview-input:focus {
+      border-color: #2563eb;
+      box-shadow: 0 0 0 3px rgba(37,99,235,0.1);
+    }
+    .preview-input.error {
+      border-color: #ef4444;
+      background: #fef2f2;
+    }
+    .preview-input.disabled {
+      background: #f3f4f6;
+      color: #9ca3af;
+      cursor: not-allowed;
+    }
+    .preview-helper {
+      font-size: 11px;
+      margin-top: 4px;
+      color: var(--color-text-tertiary);
+    }
+    .preview-helper.error {
+      color: #ef4444;
+    }
+
+    /* Comparison */
+    .comparison {
+      margin-top: var(--space-8);
+    }
+    .comparison h3 {
+      font-size: var(--font-size-lg);
+      font-weight: var(--font-weight-semibold);
+      margin-bottom: var(--space-4);
+    }
+    .comparison-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: var(--space-4);
+    }
+    @media (max-width: 640px) {
+      .comparison-grid { grid-template-columns: 1fr; }
+    }
+    .comparison-card {
+      border: 1px solid var(--color-border);
+      border-radius: var(--border-radius-lg);
+      padding: var(--space-4);
+      background: white;
+    }
+    .comparison-card.before {
+      border-color: var(--color-error);
+      border-style: dashed;
+    }
+    .comparison-card.after {
+      border-color: var(--color-success);
+    }
+    .comparison-label {
+      font-size: var(--font-size-xs);
+      font-weight: var(--font-weight-semibold);
+      text-transform: uppercase;
+      margin-bottom: var(--space-3);
+    }
+    .comparison-card.before .comparison-label { color: var(--color-error); }
+    .comparison-card.after .comparison-label { color: var(--color-success); }
+
+    .text-only-comp {
+      display: flex;
+      align-items: center;
+      gap: var(--space-2);
+      padding: var(--space-2);
+      margin-bottom: var(--space-2);
+    }
+    .text-only-comp .chip {
+      padding: 2px 8px;
+      background: var(--color-bg-tertiary);
+      border-radius: var(--border-radius-sm);
+      font-size: var(--font-size-xs);
+      font-weight: var(--font-weight-medium);
+      white-space: nowrap;
+    }
+    .text-only-comp .desc {
+      font-size: var(--font-size-xs);
+      color: var(--color-text-secondary);
+    }
+
+    /* Implementation hint */
+    .impl-hint {
+      margin-top: var(--space-6);
+      padding: var(--space-4);
+      background: var(--color-bg-secondary);
+      border-radius: var(--border-radius-md);
+      border-left: 4px solid var(--color-primary);
+      font-size: var(--font-size-sm);
+      line-height: 1.6;
+    }
+    .impl-hint strong {
+      display: block;
+      margin-bottom: var(--space-2);
+    }
+    .impl-hint code {
+      background: var(--color-bg-tertiary);
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: var(--font-size-xs);
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <a href="index.html" class="back-link">&#8592; Voltar ao indice</a>
+
+    <!-- ============================================ -->
+    <!-- ANTES vs DEPOIS -->
+    <!-- ============================================ -->
+    <div class="comparison">
+      <h3>Antes vs Depois</h3>
+      <div class="comparison-grid">
+        <div class="comparison-card before">
+          <div class="comparison-label">Antes (somente texto)</div>
+
+          <div style="font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); margin-bottom: var(--space-2);">Buttons</div>
+          <div class="text-only-comp">
+            <span class="chip">Primary</span>
+            <span class="desc">Acoes principais (aceitar, salvar)</span>
+          </div>
+          <div class="text-only-comp">
+            <span class="chip">Secondary</span>
+            <span class="desc">Acoes secundarias (cancelar, voltar)</span>
+          </div>
+          <div class="text-only-comp">
+            <span class="chip">Destructive</span>
+            <span class="desc">Acoes destrutivas (excluir, recusar)</span>
+          </div>
+
+          <div style="font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); margin-top: var(--space-3); margin-bottom: var(--space-2);">Status Badges</div>
+          <div class="text-only-comp">
+            <span class="chip">Pendente</span>
+            <span class="desc">Pedido aguardando acao</span>
+          </div>
+          <div class="text-only-comp">
+            <span class="chip">Entregue</span>
+            <span class="desc">Pedido finalizado</span>
+          </div>
+        </div>
+
+        <div class="comparison-card after">
+          <div class="comparison-label">Depois (com preview visual)</div>
+
+          <div style="font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); margin-bottom: var(--space-2);">Buttons</div>
+          <div style="display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: var(--space-3);">
+            <button class="preview-btn primary" style="font-size: 11px; padding: 4px 10px;">Primary</button>
+            <button class="preview-btn secondary" style="font-size: 11px; padding: 4px 10px;">Secondary</button>
+            <button class="preview-btn destructive" style="font-size: 11px; padding: 4px 10px;">Destructive</button>
+          </div>
+
+          <div style="font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); margin-bottom: var(--space-2);">Status Badges</div>
+          <div style="display: flex; gap: 6px; flex-wrap: wrap;">
+            <span class="preview-badge pending" style="font-size: 10px; padding: 2px 8px;">Pendente</span>
+            <span class="preview-badge delivered" style="font-size: 10px; padding: 2px 8px;">Entregue</span>
+            <span class="preview-badge cancelled" style="font-size: 10px; padding: 2px 8px;">Cancelado</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================ -->
+    <!-- COMO FICARIA NO UX PLAN -->
+    <!-- ============================================ -->
+    <div style="margin-top: var(--space-8);">
+      <h3 style="font-size: var(--font-size-lg); font-weight: var(--font-weight-semibold); margin-bottom: var(--space-2);">
+        Como ficaria no UX Plan
+      </h3>
+      <p style="font-size: var(--font-size-sm); color: var(--color-text-secondary); margin-bottom: var(--space-4);">
+        Cada grupo em <code>componentLibrary[]</code> gera uma secao com preview visual real das variantes.
+        O tipo de preview e inferido pelo <code>name</code> do grupo (ex: "Buttons" renderiza botoes reais).
+      </p>
+    </div>
+
+    <!-- Card no estilo do WorkspacePanel -->
+    <div class="plan-card">
+      <h3>Biblioteca de Componentes</h3>
+      <p class="subtitle">Preview das variantes de UI definidas para o projeto</p>
+
+      <!-- ============ GRUPO 1: BUTTONS ============ -->
+      <div class="comp-group">
+        <div class="comp-group-name">Botoes</div>
+        <div class="comp-group-preview">
+          <div class="variant-row">
+            <div class="variant-preview">
+              <button class="preview-btn primary">Primary</button>
+            </div>
+            <div class="variant-info">
+              <div class="variant-name">Primary</div>
+              <div class="variant-desc">Acoes principais (aceitar pedido, salvar, continuar)</div>
+            </div>
+          </div>
+
+          <div class="variant-row">
+            <div class="variant-preview">
+              <button class="preview-btn secondary">Secondary</button>
+            </div>
+            <div class="variant-info">
+              <div class="variant-name">Secondary</div>
+              <div class="variant-desc">Acoes secundarias (cancelar, voltar)</div>
+            </div>
+          </div>
+
+          <div class="variant-row">
+            <div class="variant-preview">
+              <button class="preview-btn destructive">Destructive</button>
+            </div>
+            <div class="variant-info">
+              <div class="variant-name">Destructive</div>
+              <div class="variant-desc">Acoes destrutivas (excluir, recusar pedido)</div>
+            </div>
+          </div>
+
+          <div class="variant-row">
+            <div class="variant-preview">
+              <button class="preview-btn ghost">Ghost</button>
+            </div>
+            <div class="variant-info">
+              <div class="variant-name">Ghost</div>
+              <div class="variant-desc">Acoes sutis, links disfarçados de botao</div>
+            </div>
+          </div>
+
+          <div class="variant-row">
+            <div class="variant-preview">
+              <button class="preview-btn outline">Outline</button>
+            </div>
+            <div class="variant-info">
+              <div class="variant-name">Outline</div>
+              <div class="variant-desc">Acoes secundarias com borda neutra</div>
+            </div>
+          </div>
+
+          <div class="variant-row">
+            <div class="variant-preview">
+              <button class="preview-btn primary disabled" disabled>Disabled</button>
+            </div>
+            <div class="variant-info">
+              <div class="variant-name">Disabled</div>
+              <div class="variant-desc">Estado desabilitado (acao nao disponivel)</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ============ GRUPO 2: STATUS BADGES ============ -->
+      <div class="comp-group">
+        <div class="comp-group-name">Status Badges</div>
+        <div class="comp-group-preview">
+          <div style="display: flex; flex-wrap: wrap; gap: var(--space-3); align-items: center;">
+            <div style="text-align: center;">
+              <span class="preview-badge pending">Pendente</span>
+              <div style="font-size: 9px; color: var(--color-text-tertiary); margin-top: 4px;">Aguardando</div>
+            </div>
+            <div style="text-align: center;">
+              <span class="preview-badge preparing">Preparando</span>
+              <div style="font-size: 9px; color: var(--color-text-tertiary); margin-top: 4px;">Em preparo</div>
+            </div>
+            <div style="text-align: center;">
+              <span class="preview-badge ready">Pronto</span>
+              <div style="font-size: 9px; color: var(--color-text-tertiary); margin-top: 4px;">Para coleta</div>
+            </div>
+            <div style="text-align: center;">
+              <span class="preview-badge delivering">Em Entrega</span>
+              <div style="font-size: 9px; color: var(--color-text-tertiary); margin-top: 4px;">A caminho</div>
+            </div>
+            <div style="text-align: center;">
+              <span class="preview-badge delivered">Entregue</span>
+              <div style="font-size: 9px; color: var(--color-text-tertiary); margin-top: 4px;">Finalizado</div>
+            </div>
+            <div style="text-align: center;">
+              <span class="preview-badge cancelled">Cancelado</span>
+              <div style="font-size: 9px; color: var(--color-text-tertiary); margin-top: 4px;">Removido</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ============ GRUPO 3: CARDS ============ -->
+      <div class="comp-group">
+        <div class="comp-group-name">Cards</div>
+        <div class="comp-group-preview">
+          <div style="display: grid; gap: var(--space-3);">
+            <div class="variant-row" style="flex-direction: column; align-items: flex-start; gap: var(--space-2);">
+              <div class="preview-card default" style="width: 100%;">
+                <div class="preview-card-title">Default Card</div>
+                <div class="preview-card-text">Borda 2px cinza, border-radius 12px, shadow leve. Usado para conteudo geral.</div>
+              </div>
+              <div class="variant-info">
+                <div class="variant-name">Default</div>
+                <div class="variant-desc">Container padrao para agrupamento de conteudo</div>
+              </div>
+            </div>
+
+            <div class="variant-row" style="flex-direction: column; align-items: flex-start; gap: var(--space-2);">
+              <div class="preview-card highlighted" style="width: 100%;">
+                <div class="preview-card-title">Highlighted Card</div>
+                <div class="preview-card-text">Borda 2px azul, shadow azul. Para itens selecionados ou em destaque.</div>
+              </div>
+              <div class="variant-info">
+                <div class="variant-name">Highlighted</div>
+                <div class="variant-desc">Card com destaque para selecao ou enfase</div>
+              </div>
+            </div>
+
+            <div class="variant-row" style="flex-direction: column; align-items: flex-start; gap: var(--space-2);">
+              <div class="preview-card elevated" style="width: 100%;">
+                <div class="preview-card-title">Elevated Card</div>
+                <div class="preview-card-text">Shadow mais pronunciado. Para cards que "flutuam" sobre o conteudo.</div>
+              </div>
+              <div class="variant-info">
+                <div class="variant-name">Elevated</div>
+                <div class="variant-desc">Card com elevacao visual (dropdowns, popovers)</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ============ GRUPO 4: FORM INPUTS ============ -->
+      <div class="comp-group">
+        <div class="comp-group-name">Form Inputs</div>
+        <div class="comp-group-preview">
+          <div style="display: grid; gap: var(--space-4);">
+            <!-- Default input -->
+            <div class="variant-row" style="flex-direction: column; align-items: flex-start; gap: var(--space-2);">
+              <div class="preview-input-group">
+                <label class="preview-input-label">Nome do Restaurante</label>
+                <input type="text" class="preview-input" placeholder="Digite o nome..." readonly>
+                <div class="preview-helper">Texto de ajuda abaixo do campo</div>
+              </div>
+              <div class="variant-info">
+                <div class="variant-name">Default</div>
+                <div class="variant-desc">Campo padrao com label, placeholder e helper text</div>
+              </div>
+            </div>
+
+            <!-- Focused input -->
+            <div class="variant-row" style="flex-direction: column; align-items: flex-start; gap: var(--space-2);">
+              <div class="preview-input-group">
+                <label class="preview-input-label">Email</label>
+                <input type="text" class="preview-input" value="usuario@email.com" style="border-color: #2563eb; box-shadow: 0 0 0 3px rgba(37,99,235,0.1);" readonly>
+              </div>
+              <div class="variant-info">
+                <div class="variant-name">Focused</div>
+                <div class="variant-desc">Estado de foco com borda azul e ring</div>
+              </div>
+            </div>
+
+            <!-- Error input -->
+            <div class="variant-row" style="flex-direction: column; align-items: flex-start; gap: var(--space-2);">
+              <div class="preview-input-group">
+                <label class="preview-input-label error">Campo com Erro</label>
+                <input type="text" class="preview-input error" value="Valor invalido" readonly>
+                <div class="preview-helper error">Este campo e obrigatorio</div>
+              </div>
+              <div class="variant-info">
+                <div class="variant-name">Error</div>
+                <div class="variant-desc">Estado de erro com borda vermelha, fundo rosa e mensagem</div>
+              </div>
+            </div>
+
+            <!-- Disabled input -->
+            <div class="variant-row" style="flex-direction: column; align-items: flex-start; gap: var(--space-2);">
+              <div class="preview-input-group">
+                <label class="preview-input-label" style="color: var(--color-text-tertiary);">Campo Desabilitado</label>
+                <input type="text" class="preview-input disabled" value="Nao editavel" disabled readonly>
+              </div>
+              <div class="variant-info">
+                <div class="variant-name">Disabled</div>
+                <div class="variant-desc">Campo desabilitado com fundo cinza e texto esmaecido</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ============ GRUPO 5: NAVIGATION / MENUS ============ -->
+      <div class="comp-group">
+        <div class="comp-group-name">Navigation Items</div>
+        <div class="comp-group-preview">
+          <div style="display: grid; gap: var(--space-3);">
+            <!-- Sidebar menu items -->
+            <div class="variant-row">
+              <div class="variant-preview" style="flex-direction: column; gap: 4px; min-width: 160px;">
+                <div style="display: flex; align-items: center; gap: 8px; padding: 6px 10px; background: var(--color-primary-light); border-radius: 6px; width: 100%;">
+                  <div style="width: 14px; height: 14px; background: var(--color-primary); border-radius: 3px;"></div>
+                  <span style="font-size: 12px; font-weight: 600; color: var(--color-primary);">Dashboard</span>
+                </div>
+                <div style="display: flex; align-items: center; gap: 8px; padding: 6px 10px; border-radius: 6px; width: 100%;">
+                  <div style="width: 14px; height: 14px; background: var(--color-gray-300); border-radius: 3px;"></div>
+                  <span style="font-size: 12px; color: var(--color-text-secondary);">Pedidos</span>
+                </div>
+                <div style="display: flex; align-items: center; gap: 8px; padding: 6px 10px; border-radius: 6px; width: 100%;">
+                  <div style="width: 14px; height: 14px; background: var(--color-gray-300); border-radius: 3px;"></div>
+                  <span style="font-size: 12px; color: var(--color-text-secondary);">Cardapio</span>
+                </div>
+              </div>
+              <div class="variant-info">
+                <div class="variant-name">Sidebar Menu</div>
+                <div class="variant-desc">Icone + label, item ativo com fundo azul, hover com fundo cinza</div>
+              </div>
+            </div>
+
+            <!-- Tab navigation -->
+            <div class="variant-row">
+              <div class="variant-preview" style="min-width: 200px;">
+                <div style="display: flex; border-bottom: 2px solid var(--color-gray-200); width: 100%;">
+                  <div style="padding: 6px 14px; font-size: 12px; font-weight: 600; color: var(--color-primary); border-bottom: 2px solid var(--color-primary); margin-bottom: -2px;">Geral</div>
+                  <div style="padding: 6px 14px; font-size: 12px; color: var(--color-text-tertiary);">Detalhes</div>
+                  <div style="padding: 6px 14px; font-size: 12px; color: var(--color-text-tertiary);">Config</div>
+                </div>
+              </div>
+              <div class="variant-info">
+                <div class="variant-name">Tab Navigation</div>
+                <div class="variant-desc">Abas horizontais com indicador de ativo na borda inferior</div>
+              </div>
+            </div>
+
+            <!-- Breadcrumb -->
+            <div class="variant-row">
+              <div class="variant-preview" style="min-width: 200px;">
+                <div style="display: flex; align-items: center; gap: 6px; font-size: 12px;">
+                  <span style="color: var(--color-primary);">Pedidos</span>
+                  <span style="color: var(--color-gray-400);">></span>
+                  <span style="color: var(--color-primary);">#1234</span>
+                  <span style="color: var(--color-gray-400);">></span>
+                  <span style="color: var(--color-text-primary); font-weight: 600;">Detalhes</span>
+                </div>
+              </div>
+              <div class="variant-info">
+                <div class="variant-name">Breadcrumb</div>
+                <div class="variant-desc">Navegacao hierarquica com links e separadores</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================ -->
+    <!-- DICAS DE IMPLEMENTACAO -->
+    <!-- ============================================ -->
+    <div class="impl-hint">
+      <strong>Dicas de Implementacao em React/Tailwind</strong>
+      <p>
+        <strong>Componente:</strong> <code>ComponentLibraryPreview</code><br>
+        <strong>Entrada:</strong> <code>componentLibrary: Array&lt;{"{"} name, variants: [{"{"} name, description {"}"}] {"}"}&gt;</code>
+      </p>
+      <p style="margin-top: var(--space-2);">
+        <strong>Logica de deteccao do tipo:</strong> Fazer <code>group.name.toLowerCase()</code> e testar keywords:
+      </p>
+      <ul style="font-size: var(--font-size-xs); margin-top: var(--space-2); padding-left: var(--space-5); line-height: 2;">
+        <li><code>button</code> / <code>botao</code> / <code>botoes</code> -> Renderizar <code>&lt;button&gt;</code> reais com classes Tailwind diferenciadas por variante</li>
+        <li><code>badge</code> / <code>status</code> / <code>tag</code> -> Renderizar pills coloridas. Mapear cores: <code>variant.name.toLowerCase()</code> contem "pend"=amarelo, "prepar"=azul, "entregue"/"done"=verde, "cancel"/"error"=vermelho</li>
+        <li><code>card</code> -> Renderizar <code>&lt;div&gt;</code> com bordas e sombras diferenciadas</li>
+        <li><code>input</code> / <code>form</code> / <code>campo</code> -> Renderizar <code>&lt;input&gt;</code> reais com estados (default, focus, error, disabled)</li>
+        <li><code>nav</code> / <code>menu</code> / <code>navigation</code> -> Renderizar listas de links simuladas</li>
+        <li>Default -> Chip generico com nome + descricao ao lado</li>
+      </ul>
+      <p style="margin-top: var(--space-3);">
+        <strong>Mapeamento de cores para badges:</strong><br>
+        Para inferir a cor de cada variante sem dados extras, usar heuristica baseada no nome:
+      </p>
+      <pre style="font-size: var(--font-size-xs); margin-top: var(--space-2); background: var(--color-bg-tertiary); padding: var(--space-3); border-radius: var(--border-radius-sm); overflow-x: auto; line-height: 1.8;">
+const BADGE_COLORS: Record&lt;string, {bg: string, text: string}&gt; = {
+  pending:    { bg: 'bg-amber-100',  text: 'text-amber-800'  },
+  preparing:  { bg: 'bg-blue-100',   text: 'text-blue-800'   },
+  ready:      { bg: 'bg-amber-100',  text: 'text-amber-800'  },
+  delivering: { bg: 'bg-purple-100', text: 'text-purple-800' },
+  delivered:  { bg: 'bg-green-100',  text: 'text-green-800'  },
+  cancelled:  { bg: 'bg-red-100',    text: 'text-red-800'    },
+  success:    { bg: 'bg-green-100',  text: 'text-green-800'  },
+  warning:    { bg: 'bg-amber-100',  text: 'text-amber-800'  },
+  error:      { bg: 'bg-red-100',    text: 'text-red-800'    },
+  info:       { bg: 'bg-blue-100',   text: 'text-blue-800'   },
+  default:    { bg: 'bg-gray-100',   text: 'text-gray-800'   },
+}
+
+function getBadgeColor(variantName: string) {
+  const key = variantName.toLowerCase()
+  for (const [pattern, colors] of Object.entries(BADGE_COLORS)) {
+    if (key.includes(pattern)) return colors
+  }
+  return BADGE_COLORS.default
+}
+      </pre>
+    </div>
+  </div>
+</body>
+</html>

--- a/mockups/project/phase-2-planning/ux-visual-sections/index.html
+++ b/mockups/project/phase-2-planning/ux-visual-sections/index.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>UX Visual Sections - Mockups | True Coding</title>
+  <link rel="stylesheet" href="../../../css/tokens.css">
+  <style>
+    body {
+      background: var(--color-bg-secondary);
+      padding: var(--space-8);
+    }
+    .hub {
+      max-width: 720px;
+      margin: 0 auto;
+    }
+    .hub h1 {
+      font-size: var(--font-size-2xl);
+      font-weight: var(--font-weight-bold);
+      margin-bottom: var(--space-2);
+    }
+    .hub p {
+      color: var(--color-text-secondary);
+      margin-bottom: var(--space-6);
+      line-height: 1.6;
+    }
+    .hub-grid {
+      display: grid;
+      gap: var(--space-4);
+    }
+    .hub-card {
+      background: white;
+      border: 2px solid var(--color-border);
+      border-radius: var(--border-radius-xl);
+      padding: var(--space-6);
+      text-decoration: none;
+      color: inherit;
+      transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+    }
+    .hub-card:hover {
+      border-color: var(--color-primary);
+      box-shadow: 0 4px 12px rgba(37, 99, 235, 0.1);
+    }
+    .hub-card h2 {
+      font-size: var(--font-size-lg);
+      font-weight: var(--font-weight-semibold);
+      margin-bottom: var(--space-2);
+    }
+    .hub-card p {
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+      margin: 0;
+    }
+    .hub-card .tag {
+      display: inline-block;
+      padding: 2px 10px;
+      background: var(--color-primary-light);
+      color: var(--color-primary);
+      border-radius: var(--border-radius-full);
+      font-size: var(--font-size-xs);
+      font-weight: var(--font-weight-medium);
+      margin-bottom: var(--space-3);
+    }
+    .back-link {
+      display: inline-block;
+      margin-bottom: var(--space-6);
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+    }
+    .back-link:hover {
+      color: var(--color-primary);
+    }
+    .context-box {
+      background: white;
+      border: 1px solid var(--color-border);
+      border-left: 4px solid var(--color-primary);
+      border-radius: var(--border-radius-md);
+      padding: var(--space-4);
+      margin-bottom: var(--space-6);
+      font-size: var(--font-size-sm);
+      line-height: 1.6;
+    }
+    .context-box strong {
+      display: block;
+      margin-bottom: var(--space-1);
+    }
+  </style>
+</head>
+<body>
+  <div class="hub">
+    <a href="../07-ux-plan.html" class="back-link">&#8592; Voltar ao UX Plan completo</a>
+
+    <h1>Secoes Visuais do UX Plan</h1>
+    <p>
+      Mockups demonstrando como as 3 secoes visuais do UX Plan podem ser renderizadas
+      com HTML/CSS/SVG diretamente no React, sem geracao de imagens por IA.
+    </p>
+
+    <div class="context-box">
+      <strong>Contexto da Issue #39</strong>
+      Atualmente as secoes Navegacao Principal, Wireframes e Biblioteca de Componentes
+      mostram apenas texto descritivo. Estes mockups demonstram a representacao visual
+      esquematica proposta, usando dados do JSON gerado pela IA.
+    </div>
+
+    <div class="hub-grid">
+      <a href="01-navigation-preview.html" class="hub-card">
+        <span class="tag">Secao 2 - Arquitetura de Informacao</span>
+        <h2>01. Navegacao Principal</h2>
+        <p>
+          Wireframes esquematicos dos padroes de navegacao: Sidebar, Bottom Tab Bar,
+          Top Tabs, Breadcrumbs. Cada padrao renderizado como SVG/HTML baseado no campo
+          <code>navigation[].name</code>.
+        </p>
+      </a>
+
+      <a href="02-wireframe-preview.html" class="hub-card">
+        <span class="tag">Secao 4 - Wireframes</span>
+        <h2>02. Wireframes e Fluxos</h2>
+        <p>
+          Wireframes esquematicos das telas principais: Dashboard, Detalhes do Pedido,
+          Cardapio Publico. Layouts inferidos do campo <code>wireframes[].layout</code>,
+          renderizados como grid HTML/CSS.
+        </p>
+      </a>
+
+      <a href="03-component-library-preview.html" class="hub-card">
+        <span class="tag">Secao 5 - Componentes</span>
+        <h2>03. Biblioteca de Componentes</h2>
+        <p>
+          Preview visual de botoes, badges, cards e form inputs. Cada variante renderizada
+          como componente real com Tailwind CSS, baseado no campo
+          <code>componentLibrary[].variants</code>.
+        </p>
+      </a>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/components/project/WorkspacePanel.test.tsx
+++ b/src/components/project/WorkspacePanel.test.tsx
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { WorkspacePanel } from './WorkspacePanel'
+
+// Mock useProjectLayout
+vi.mock('./ProjectLayout', () => ({
+  useProjectLayout: () => ({
+    sidebarOpen: false,
+    setSidebarOpen: vi.fn(),
+    chatOpen: false,
+    setChatOpen: vi.fn(),
+  }),
+}))
+
+const baseProps = {
+  projectId: 'test-1',
+  projectName: 'Test Project',
+  status: 'PLANNING',
+  businessPlanApproved: true,
+  technicalPlanApproved: true,
+  uxPlanApproved: false,
+}
+
+function makeUxPlan(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    personas: [{ name: 'User', initials: 'U', bio: 'Test persona' }],
+    informationArchitecture: {
+      sitemap: 'Home > Dashboard',
+      navigation: [
+        { name: 'Sidebar Principal', description: 'Navegação lateral fixa' },
+        { name: 'Bottom Tab Bar', description: 'Barra inferior para mobile' },
+        { name: 'Tabs Horizontais', description: 'Abas no topo' },
+        { name: 'Breadcrumb Trail', description: 'Caminho hierárquico' },
+      ],
+    },
+    wireframes: [
+      { name: 'Dashboard', description: 'Tela principal', layout: 'Sidebar fixa + grid de cards' },
+      { name: 'Lista de Pedidos', description: 'Listagem', layout: 'List com filtros' },
+      { name: 'Formulário', description: 'Cadastro', layout: 'Form centralizado' },
+      { name: 'App Mobile', description: 'Versão mobile', layout: 'Mobile app com bottom nav' },
+      { name: 'Catálogo', description: 'Grid de itens', layout: 'Grid de cards' },
+      { name: 'Genérica', description: 'Tela sem layout', layout: '' },
+    ],
+    componentLibrary: [
+      {
+        name: 'Buttons',
+        variants: [
+          { name: 'Primary', description: 'Ação principal' },
+          { name: 'Destructive', description: 'Ação destrutiva' },
+          { name: 'Ghost', description: 'Ação sutil' },
+        ],
+      },
+      {
+        name: 'Status Badges',
+        variants: [
+          { name: 'Pendente', description: 'Aguardando' },
+          { name: 'Entregue', description: 'Finalizado' },
+          { name: 'Cancelado', description: 'Removido' },
+        ],
+      },
+      {
+        name: 'Cards',
+        variants: [
+          { name: 'Default', description: 'Card padrão' },
+          { name: 'Highlighted', description: 'Card com destaque' },
+        ],
+      },
+      {
+        name: 'Form Inputs',
+        variants: [
+          { name: 'Default', description: 'Campo padrão' },
+          { name: 'Error', description: 'Campo com erro' },
+          { name: 'Disabled', description: 'Campo desabilitado' },
+        ],
+      },
+      {
+        name: 'Outro Componente',
+        variants: [
+          { name: 'Variante A', description: 'Genérica' },
+        ],
+      },
+    ],
+    ...overrides,
+  })
+}
+
+describe('WorkspacePanel - UX Plan Visual Previews', () => {
+  describe('NavigationPatternCard', () => {
+    it('renders sidebar wireframe for navigation with "Sidebar" in name', () => {
+      const { container } = render(
+        <WorkspacePanel {...baseProps} uxPlan={makeUxPlan()} />
+      )
+      const svgs = container.querySelectorAll('svg[aria-label]')
+      const labels = Array.from(svgs).map((s) => s.getAttribute('aria-label'))
+      expect(labels).toContain('Wireframe de navegação sidebar')
+    })
+
+    it('renders bottom bar wireframe for "Bottom Tab Bar"', () => {
+      const { container } = render(
+        <WorkspacePanel {...baseProps} uxPlan={makeUxPlan()} />
+      )
+      const svgs = container.querySelectorAll('svg[aria-label]')
+      const labels = Array.from(svgs).map((s) => s.getAttribute('aria-label'))
+      expect(labels).toContain('Wireframe de navegação bottom bar')
+    })
+
+    it('renders tabs wireframe for "Tabs Horizontais"', () => {
+      const { container } = render(
+        <WorkspacePanel {...baseProps} uxPlan={makeUxPlan()} />
+      )
+      const svgs = container.querySelectorAll('svg[aria-label]')
+      const labels = Array.from(svgs).map((s) => s.getAttribute('aria-label'))
+      expect(labels).toContain('Wireframe de navegação por tabs')
+    })
+
+    it('renders breadcrumb wireframe for "Breadcrumb Trail"', () => {
+      const { container } = render(
+        <WorkspacePanel {...baseProps} uxPlan={makeUxPlan()} />
+      )
+      const svgs = container.querySelectorAll('svg[aria-label]')
+      const labels = Array.from(svgs).map((s) => s.getAttribute('aria-label'))
+      expect(labels).toContain('Wireframe de navegação breadcrumb')
+    })
+
+    it('renders generic wireframe for unrecognized patterns', () => {
+      const uxPlan = makeUxPlan({
+        informationArchitecture: {
+          navigation: [{ name: 'Padrão Desconhecido', description: 'Teste' }],
+        },
+      })
+      const { container } = render(
+        <WorkspacePanel {...baseProps} uxPlan={uxPlan} />
+      )
+      const svgs = container.querySelectorAll('svg[aria-label="Wireframe de navegação genérica"]')
+      expect(svgs.length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  describe('WireframeCard', () => {
+    it('renders sidebar layout wireframe when layout includes "sidebar"', () => {
+      const { container } = render(
+        <WorkspacePanel {...baseProps} uxPlan={makeUxPlan()} />
+      )
+      const svgs = container.querySelectorAll('svg[aria-label]')
+      const labels = Array.from(svgs).map((s) => s.getAttribute('aria-label'))
+      expect(labels).toContain('Wireframe com sidebar')
+    })
+
+    it('renders list layout wireframe when layout includes "list"', () => {
+      const { container } = render(
+        <WorkspacePanel {...baseProps} uxPlan={makeUxPlan()} />
+      )
+      const svgs = container.querySelectorAll('svg[aria-label]')
+      const labels = Array.from(svgs).map((s) => s.getAttribute('aria-label'))
+      expect(labels).toContain('Wireframe com layout de lista')
+    })
+
+    it('renders form layout wireframe when layout includes "form"', () => {
+      const { container } = render(
+        <WorkspacePanel {...baseProps} uxPlan={makeUxPlan()} />
+      )
+      const svgs = container.querySelectorAll('svg[aria-label]')
+      const labels = Array.from(svgs).map((s) => s.getAttribute('aria-label'))
+      expect(labels).toContain('Wireframe com layout de formulário')
+    })
+
+    it('renders mobile layout wireframe when layout includes "mobile"', () => {
+      const { container } = render(
+        <WorkspacePanel {...baseProps} uxPlan={makeUxPlan()} />
+      )
+      const svgs = container.querySelectorAll('svg[aria-label]')
+      const labels = Array.from(svgs).map((s) => s.getAttribute('aria-label'))
+      expect(labels).toContain('Wireframe de layout mobile')
+    })
+
+    it('renders grid layout wireframe when layout includes "grid"', () => {
+      const { container } = render(
+        <WorkspacePanel {...baseProps} uxPlan={makeUxPlan()} />
+      )
+      const svgs = container.querySelectorAll('svg[aria-label]')
+      const labels = Array.from(svgs).map((s) => s.getAttribute('aria-label'))
+      expect(labels).toContain('Wireframe com grid de cards')
+    })
+
+    it('renders generic wireframe for empty layout', () => {
+      const { container } = render(
+        <WorkspacePanel {...baseProps} uxPlan={makeUxPlan()} />
+      )
+      const svgs = container.querySelectorAll('svg[aria-label="Wireframe de layout genérico"]')
+      expect(svgs.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('shows layout label text', () => {
+      render(<WorkspacePanel {...baseProps} uxPlan={makeUxPlan()} />)
+      expect(screen.getByText(/Layout: Sidebar fixa/)).toBeInTheDocument()
+      expect(screen.getByText(/Layout: List com filtros/)).toBeInTheDocument()
+    })
+  })
+
+  describe('ComponentGroupPreview', () => {
+    it('renders real buttons for "Buttons" group', () => {
+      render(<WorkspacePanel {...baseProps} uxPlan={makeUxPlan()} />)
+      const buttons = screen.getAllByRole('button')
+      const buttonLabels = buttons.map((b) => b.textContent)
+      expect(buttonLabels).toContain('Primary')
+      expect(buttonLabels).toContain('Destructive')
+      expect(buttonLabels).toContain('Ghost')
+    })
+
+    it('renders colored badges for "Status Badges" group', () => {
+      render(<WorkspacePanel {...baseProps} uxPlan={makeUxPlan()} />)
+      const pendentes = screen.getAllByText('Pendente')
+      const badge = pendentes.find((el) => el.classList.contains('rounded-full'))
+      expect(badge).toBeDefined()
+      expect(badge!.className).toMatch(/bg-amber/)
+
+      const entregues = screen.getAllByText('Entregue')
+      const entBadge = entregues.find((el) => el.classList.contains('rounded-full'))
+      expect(entBadge!.className).toMatch(/bg-green/)
+
+      const cancelados = screen.getAllByText('Cancelado')
+      const canBadge = cancelados.find((el) => el.classList.contains('rounded-full'))
+      expect(canBadge!.className).toMatch(/bg-red/)
+    })
+
+    it('renders card variants with differentiated styles', () => {
+      render(<WorkspacePanel {...baseProps} uxPlan={makeUxPlan()} />)
+      expect(screen.getByText('Card padrão')).toBeInTheDocument()
+      expect(screen.getByText('Card com destaque')).toBeInTheDocument()
+    })
+
+    it('renders input variants with different states', () => {
+      render(<WorkspacePanel {...baseProps} uxPlan={makeUxPlan()} />)
+      const inputs = screen.getAllByRole('textbox')
+      const disabledInputs = inputs.filter((i) => i.hasAttribute('disabled'))
+      expect(disabledInputs.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('renders default chip-style fallback for unrecognized groups', () => {
+      render(<WorkspacePanel {...baseProps} uxPlan={makeUxPlan()} />)
+      expect(screen.getByText('Variante A')).toBeInTheDocument()
+      // "Genérica" appears both as wireframe description and variant description
+      const genericas = screen.getAllByText('Genérica')
+      expect(genericas.length).toBeGreaterThanOrEqual(1)
+    })
+  })
+})

--- a/src/components/project/WorkspacePanel.tsx
+++ b/src/components/project/WorkspacePanel.tsx
@@ -1110,13 +1110,10 @@ function UxPlanView({
           )}
           {uxPlanParsed.informationArchitecture.navigation && uxPlanParsed.informationArchitecture.navigation.length > 0 && (
             <div>
-              <p className="mb-2 text-sm font-semibold">Navegação Principal</p>
-              <div className="space-y-2">
+              <p className="mb-3 text-sm font-semibold">Navegação Principal</p>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 {uxPlanParsed.informationArchitecture.navigation.map((nav, i) => (
-                  <div key={i} className="rounded-lg bg-muted/50 p-3">
-                    <p className="text-sm font-semibold">{nav.name}</p>
-                    <p className="text-xs text-muted-foreground">{nav.description}</p>
-                  </div>
+                  <NavigationPatternCard key={i} name={nav.name} description={nav.description} />
                 ))}
               </div>
             </div>
@@ -1158,13 +1155,10 @@ function UxPlanView({
       {uxPlanParsed.wireframes && uxPlanParsed.wireframes.length > 0 && (
         <div className="rounded-xl border bg-card p-6">
           <h3 className="mb-4 text-lg font-semibold">📐 Wireframes e Fluxos</h3>
-          <div className="space-y-3">
+          <p className="mb-4 text-xs text-muted-foreground">Representação esquemática dos layouts principais</p>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             {uxPlanParsed.wireframes.map((wf, i) => (
-              <div key={i} className="rounded-lg bg-muted/50 p-3">
-                <p className="font-semibold">{wf.name}</p>
-                <p className="text-sm text-muted-foreground">{wf.description}</p>
-                {wf.layout && <p className="mt-1 text-xs text-gray-500">{wf.layout}</p>}
-              </div>
+              <WireframeCard key={i} name={wf.name} description={wf.description} layout={wf.layout} />
             ))}
           </div>
         </div>
@@ -1174,19 +1168,10 @@ function UxPlanView({
       {uxPlanParsed.componentLibrary && uxPlanParsed.componentLibrary.length > 0 && (
         <div className="rounded-xl border bg-card p-6">
           <h3 className="mb-4 text-lg font-semibold">🧩 Biblioteca de Componentes</h3>
-          <div className="space-y-4">
+          <p className="mb-4 text-xs text-muted-foreground">Preview das variantes de UI definidas para o projeto</p>
+          <div className="space-y-5">
             {uxPlanParsed.componentLibrary.map((group, i) => (
-              <div key={i}>
-                <p className="mb-2 text-sm font-semibold">{group.name}</p>
-                <div className="space-y-2 rounded-lg bg-muted/50 p-3">
-                  {group.variants.map((variant, j) => (
-                    <div key={j} className="flex items-center gap-3">
-                      <span className="rounded-md bg-background px-2 py-1 text-xs font-medium">{variant.name}</span>
-                      <span className="text-xs text-muted-foreground">{variant.description}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
+              <ComponentGroupPreview key={i} name={group.name} variants={group.variants} />
             ))}
           </div>
         </div>
@@ -1514,6 +1499,359 @@ function FileProgress({ name, status }: { name: string; status: 'done' | 'genera
       )}
       {status === 'pending' && <div className="h-4 w-4 rounded-full border-2 border-muted" />}
       <span className={`text-sm ${status === 'pending' ? 'text-muted-foreground' : ''}`}>{name}</span>
+    </div>
+  )
+}
+
+// ============================================================
+// Visual Preview Components for UX Plan (Issue #39)
+// ============================================================
+
+// --- Navigation Pattern Card ---
+function NavigationPatternCard({ name, description }: { name: string; description: string }) {
+  const key = name.toLowerCase()
+  return (
+    <div className="group rounded-lg border bg-muted/30 p-3 transition-colors hover:border-blue-200">
+      <div className="mb-2 flex aspect-[16/10] items-center justify-center rounded bg-gray-50" aria-hidden="true">
+        {key.includes('sidebar') ? <SidebarWireframe /> :
+         key.includes('bottom') || key.includes('tab bar') ? <BottomBarWireframe /> :
+         key.includes('tab') ? <TopTabsWireframe /> :
+         key.includes('breadcrumb') ? <BreadcrumbWireframe /> :
+         <GenericNavWireframe />}
+      </div>
+      <p className="text-sm font-semibold">{name}</p>
+      <p className="text-xs text-muted-foreground">{description}</p>
+    </div>
+  )
+}
+
+function SidebarWireframe() {
+  return (
+    <svg viewBox="0 0 200 140" className="h-full w-full max-h-[100px]" role="img" aria-label="Wireframe de navegação sidebar">
+      <rect x="2" y="2" width="50" height="136" rx="4" fill="#e5e7eb" stroke="#d1d5db" strokeWidth="1" />
+      {[20, 38, 56, 74, 92].map((y) => (
+        <rect key={y} x="10" y={y} width="34" height="8" rx="2" fill={y === 20 ? '#93c5fd' : '#d1d5db'} />
+      ))}
+      <rect x="60" y="2" width="138" height="136" rx="4" fill="#f9fafb" stroke="#e5e7eb" strokeWidth="1" />
+      <rect x="70" y="14" width="80" height="8" rx="2" fill="#d1d5db" />
+      <rect x="70" y="32" width="118" height="40" rx="4" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="1" />
+      <rect x="70" y="82" width="56" height="40" rx="4" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="1" />
+      <rect x="132" y="82" width="56" height="40" rx="4" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="1" />
+    </svg>
+  )
+}
+
+function BottomBarWireframe() {
+  return (
+    <svg viewBox="0 0 200 140" className="h-full w-full max-h-[100px]" role="img" aria-label="Wireframe de navegação bottom bar">
+      <rect x="2" y="2" width="196" height="108" rx="4" fill="#f9fafb" stroke="#e5e7eb" strokeWidth="1" />
+      <rect x="12" y="14" width="80" height="8" rx="2" fill="#d1d5db" />
+      <rect x="12" y="32" width="176" height="30" rx="4" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="1" />
+      <rect x="12" y="70" width="84" height="30" rx="4" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="1" />
+      <rect x="104" y="70" width="84" height="30" rx="4" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="1" />
+      <rect x="2" y="114" width="196" height="24" rx="4" fill="#e5e7eb" stroke="#d1d5db" strokeWidth="1" />
+      {[30, 70, 110, 150].map((x) => (
+        <circle key={x} cx={x} cy="126" r="6" fill="#d1d5db" />
+      ))}
+      <circle cx="70" cy="126" r="6" fill="#93c5fd" />
+    </svg>
+  )
+}
+
+function TopTabsWireframe() {
+  return (
+    <svg viewBox="0 0 200 140" className="h-full w-full max-h-[100px]" role="img" aria-label="Wireframe de navegação por tabs">
+      <rect x="2" y="2" width="196" height="136" rx="4" fill="#f9fafb" stroke="#e5e7eb" strokeWidth="1" />
+      <rect x="2" y="2" width="196" height="28" rx="4" fill="#e5e7eb" />
+      <rect x="10" y="8" width="40" height="16" rx="3" fill="#93c5fd" />
+      <rect x="56" y="8" width="40" height="16" rx="3" fill="#d1d5db" />
+      <rect x="102" y="8" width="40" height="16" rx="3" fill="#d1d5db" />
+      <rect x="12" y="42" width="176" height="40" rx="4" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="1" />
+      <rect x="12" y="92" width="176" height="36" rx="4" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="1" />
+    </svg>
+  )
+}
+
+function BreadcrumbWireframe() {
+  return (
+    <svg viewBox="0 0 200 140" className="h-full w-full max-h-[100px]" role="img" aria-label="Wireframe de navegação breadcrumb">
+      <rect x="2" y="2" width="196" height="136" rx="4" fill="#f9fafb" stroke="#e5e7eb" strokeWidth="1" />
+      <rect x="10" y="10" width="30" height="10" rx="2" fill="#93c5fd" />
+      <text x="46" y="18" fontSize="10" fill="#9ca3af">&gt;</text>
+      <rect x="56" y="10" width="40" height="10" rx="2" fill="#93c5fd" />
+      <text x="102" y="18" fontSize="10" fill="#9ca3af">&gt;</text>
+      <rect x="112" y="10" width="50" height="10" rx="2" fill="#6b7280" />
+      <rect x="10" y="30" width="180" height="100" rx="4" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="1" />
+    </svg>
+  )
+}
+
+function GenericNavWireframe() {
+  return (
+    <svg viewBox="0 0 200 140" className="h-full w-full max-h-[100px]" role="img" aria-label="Wireframe de navegação genérica">
+      <rect x="2" y="2" width="196" height="136" rx="4" fill="#f9fafb" stroke="#e5e7eb" strokeWidth="1" />
+      <rect x="10" y="10" width="20" height="12" rx="2" fill="#d1d5db" />
+      <rect x="10" y="30" width="180" height="100" rx="4" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="1" />
+    </svg>
+  )
+}
+
+// --- Wireframe Card ---
+function WireframeCard({ name, description, layout }: { name: string; description: string; layout?: string }) {
+  const key = (layout || '').toLowerCase()
+  return (
+    <div className="group rounded-lg border bg-card p-3 transition-colors hover:border-blue-200 hover:shadow-sm">
+      <p className="mb-2 text-sm font-semibold">{name}</p>
+      <div className="mb-2 flex aspect-[16/10] items-center justify-center rounded bg-gray-50" aria-hidden="true">
+        {key.includes('sidebar') ? <SidebarLayoutWireframe /> :
+         key.includes('card') || key.includes('grid') ? <GridLayoutWireframe /> :
+         key.includes('list') || key.includes('table') || key.includes('lista') ? <ListLayoutWireframe /> :
+         key.includes('form') || key.includes('formulário') || key.includes('formulario') ? <FormLayoutWireframe /> :
+         key.includes('mobile') || key.includes('app') ? <MobileLayoutWireframe /> :
+         <GenericLayoutWireframe />}
+      </div>
+      <p className="line-clamp-2 text-xs text-muted-foreground">{description}</p>
+      {layout && <p className="mt-1 text-xs text-gray-400">Layout: {layout}</p>}
+    </div>
+  )
+}
+
+function SidebarLayoutWireframe() {
+  return (
+    <svg viewBox="0 0 200 125" className="h-full w-full max-h-[90px]" role="img" aria-label="Wireframe com sidebar">
+      <rect x="2" y="2" width="45" height="121" rx="3" fill="#e5e7eb" />
+      {[14, 30, 46, 62].map((y) => (
+        <rect key={y} x="8" y={y} width="33" height="8" rx="2" fill="#d1d5db" />
+      ))}
+      <rect x="55" y="2" width="143" height="121" rx="3" fill="#f9fafb" stroke="#e5e7eb" strokeWidth="1" />
+      <rect x="63" y="12" width="60" height="6" rx="2" fill="#d1d5db" />
+      <rect x="63" y="26" width="127" height="35" rx="3" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="1" />
+      <rect x="63" y="69" width="60" height="45" rx="3" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="1" />
+      <rect x="130" y="69" width="60" height="45" rx="3" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="1" />
+    </svg>
+  )
+}
+
+function GridLayoutWireframe() {
+  return (
+    <svg viewBox="0 0 200 125" className="h-full w-full max-h-[90px]" role="img" aria-label="Wireframe com grid de cards">
+      <rect x="2" y="2" width="196" height="20" rx="3" fill="#e5e7eb" />
+      <rect x="8" y="7" width="50" height="10" rx="2" fill="#d1d5db" />
+      {[[8, 30], [104, 30], [8, 78], [104, 78]].map(([x, y], i) => (
+        <rect key={i} x={x} y={y} width="88" height="40" rx="4" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="1" />
+      ))}
+    </svg>
+  )
+}
+
+function ListLayoutWireframe() {
+  return (
+    <svg viewBox="0 0 200 125" className="h-full w-full max-h-[90px]" role="img" aria-label="Wireframe com layout de lista">
+      <rect x="2" y="2" width="196" height="20" rx="3" fill="#e5e7eb" />
+      <rect x="8" y="7" width="50" height="10" rx="2" fill="#d1d5db" />
+      {[30, 52, 74, 96].map((y) => (
+        <g key={y}>
+          <rect x="8" y={y} width="184" height="16" rx="3" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="1" />
+          <rect x="14" y={y + 4} width="60" height="8" rx="2" fill="#d1d5db" />
+          <rect x="80" y={y + 4} width="40" height="8" rx="2" fill="#e5e7eb" />
+        </g>
+      ))}
+    </svg>
+  )
+}
+
+function FormLayoutWireframe() {
+  return (
+    <svg viewBox="0 0 200 125" className="h-full w-full max-h-[90px]" role="img" aria-label="Wireframe com layout de formulário">
+      <rect x="30" y="2" width="140" height="121" rx="4" fill="#f9fafb" stroke="#e5e7eb" strokeWidth="1" />
+      <rect x="40" y="10" width="60" height="6" rx="2" fill="#d1d5db" />
+      {[24, 50, 76].map((y) => (
+        <g key={y}>
+          <rect x="40" y={y} width="30" height="5" rx="1" fill="#9ca3af" />
+          <rect x="40" y={y + 8} width="120" height="14" rx="3" fill="#f3f4f6" stroke="#d1d5db" strokeWidth="1" />
+        </g>
+      ))}
+      <rect x="110" y="104" width="50" height="14" rx="3" fill="#93c5fd" />
+    </svg>
+  )
+}
+
+function MobileLayoutWireframe() {
+  return (
+    <svg viewBox="0 0 200 125" className="h-full w-full max-h-[90px]" role="img" aria-label="Wireframe de layout mobile">
+      <rect x="65" y="2" width="70" height="121" rx="10" fill="#f9fafb" stroke="#d1d5db" strokeWidth="1.5" />
+      <rect x="85" y="6" width="30" height="4" rx="2" fill="#e5e7eb" />
+      <rect x="72" y="16" width="56" height="10" rx="2" fill="#e5e7eb" />
+      <rect x="72" y="32" width="56" height="30" rx="3" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="1" />
+      <rect x="72" y="68" width="56" height="20" rx="3" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="1" />
+      <rect x="72" y="94" width="56" height="10" rx="2" fill="#93c5fd" />
+      <rect x="72" y="110" width="56" height="8" rx="2" fill="#e5e7eb" />
+    </svg>
+  )
+}
+
+function GenericLayoutWireframe() {
+  return (
+    <svg viewBox="0 0 200 125" className="h-full w-full max-h-[90px]" role="img" aria-label="Wireframe de layout genérico">
+      <rect x="2" y="2" width="196" height="20" rx="3" fill="#e5e7eb" />
+      <rect x="8" y="7" width="50" height="10" rx="2" fill="#d1d5db" />
+      <rect x="8" y="30" width="184" height="60" rx="4" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="1" />
+      <rect x="8" y="98" width="184" height="20" rx="3" fill="#e5e7eb" />
+    </svg>
+  )
+}
+
+// --- Component Group Preview ---
+function ComponentGroupPreview({ name, variants }: { name: string; variants: Array<{ name: string; description: string }> }) {
+  const key = name.toLowerCase()
+  const isButton = key.includes('button') || key.includes('botão') || key.includes('botao') || key.includes('botões') || key.includes('botoes')
+  const isBadge = key.includes('badge') || key.includes('status') || key.includes('tag')
+  const isCard = key.includes('card')
+  const isInput = key.includes('input') || key.includes('form') || key.includes('campo')
+
+  return (
+    <div>
+      <p className="mb-2 text-sm font-semibold">{name}</p>
+      <div className="rounded-lg bg-muted/30 p-4">
+        {isButton ? <ButtonVariantsPreview variants={variants} /> :
+         isBadge ? <BadgeVariantsPreview variants={variants} /> :
+         isCard ? <CardVariantsPreview variants={variants} /> :
+         isInput ? <InputVariantsPreview variants={variants} /> :
+         <DefaultVariantsPreview variants={variants} />}
+      </div>
+    </div>
+  )
+}
+
+function ButtonVariantsPreview({ variants }: { variants: Array<{ name: string; description: string }> }) {
+  const buttonStyles: Record<string, string> = {
+    primary: 'bg-blue-600 text-white hover:bg-blue-700',
+    secondary: 'border border-gray-300 bg-white text-gray-700 hover:bg-gray-50',
+    destructive: 'bg-red-500 text-white hover:bg-red-600',
+    ghost: 'text-gray-600 hover:bg-gray-100',
+    outline: 'border border-gray-300 text-gray-700 hover:bg-gray-50',
+    disabled: 'bg-gray-200 text-gray-400 cursor-not-allowed',
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2">
+        {variants.map((v, i) => {
+          const vKey = v.name.toLowerCase()
+          const style = Object.entries(buttonStyles).find(([k]) => vKey.includes(k))?.[1] || buttonStyles.secondary
+          return (
+            <button key={i} className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${style}`} disabled={vKey.includes('disabled')}>
+              {v.name}
+            </button>
+          )
+        })}
+      </div>
+      <div className="space-y-1">
+        {variants.map((v, i) => (
+          <p key={i} className="text-xs text-muted-foreground"><span className="font-medium text-foreground">{v.name}</span> — {v.description}</p>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function BadgeVariantsPreview({ variants }: { variants: Array<{ name: string; description: string }> }) {
+  const badgeColors: Record<string, string> = {
+    pend: 'bg-amber-100 text-amber-800',
+    prepar: 'bg-blue-100 text-blue-800',
+    process: 'bg-blue-100 text-blue-800',
+    ready: 'bg-amber-100 text-amber-800',
+    pronto: 'bg-amber-100 text-amber-800',
+    deliver: 'bg-purple-100 text-purple-800',
+    entreg: 'bg-green-100 text-green-800',
+    done: 'bg-green-100 text-green-800',
+    success: 'bg-green-100 text-green-800',
+    cancel: 'bg-red-100 text-red-800',
+    error: 'bg-red-100 text-red-800',
+    warning: 'bg-amber-100 text-amber-800',
+    info: 'bg-blue-100 text-blue-800',
+    active: 'bg-green-100 text-green-800',
+    inactive: 'bg-gray-100 text-gray-800',
+  }
+
+  function getBadgeColor(variantName: string) {
+    const k = variantName.toLowerCase()
+    for (const [pattern, color] of Object.entries(badgeColors)) {
+      if (k.includes(pattern)) return color
+    }
+    return 'bg-gray-100 text-gray-800'
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2">
+        {variants.map((v, i) => (
+          <span key={i} className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${getBadgeColor(v.name)}`}>
+            {v.name}
+          </span>
+        ))}
+      </div>
+      <div className="space-y-1">
+        {variants.map((v, i) => (
+          <p key={i} className="text-xs text-muted-foreground"><span className="font-medium text-foreground">{v.name}</span> — {v.description}</p>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function CardVariantsPreview({ variants }: { variants: Array<{ name: string; description: string }> }) {
+  return (
+    <div className="space-y-3">
+      {variants.map((v, i) => {
+        const vKey = v.name.toLowerCase()
+        const borderClass = vKey.includes('highlight') ? 'border-blue-300 shadow-blue-100' : vKey.includes('elevat') ? 'shadow-md' : ''
+        return (
+          <div key={i} className={`rounded-lg border bg-white p-3 ${borderClass}`}>
+            <p className="text-xs font-semibold text-gray-700">{v.name}</p>
+            <p className="text-xs text-gray-400">{v.description}</p>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function InputVariantsPreview({ variants }: { variants: Array<{ name: string; description: string }> }) {
+  return (
+    <div className="space-y-3">
+      {variants.map((v, i) => {
+        const vKey = v.name.toLowerCase()
+        const isError = vKey.includes('error') || vKey.includes('erro')
+        const isDisabled = vKey.includes('disabled') || vKey.includes('desab')
+        const isFocused = vKey.includes('focus') || vKey.includes('foco')
+        const borderClass = isError ? 'border-red-400 bg-red-50' : isFocused ? 'border-blue-500 ring-2 ring-blue-100' : isDisabled ? 'border-gray-200 bg-gray-100 text-gray-400' : 'border-gray-300'
+        return (
+          <div key={i}>
+            <label className={`mb-1 block text-xs font-medium ${isError ? 'text-red-600' : 'text-gray-600'}`}>{v.name}</label>
+            <input
+              type="text"
+              readOnly
+              disabled={isDisabled}
+              placeholder={v.description}
+              className={`w-full rounded-md border px-3 py-1.5 text-xs ${borderClass}`}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function DefaultVariantsPreview({ variants }: { variants: Array<{ name: string; description: string }> }) {
+  return (
+    <div className="space-y-2">
+      {variants.map((v, i) => (
+        <div key={i} className="flex items-center gap-3">
+          <span className="rounded-md bg-background px-2 py-1 text-xs font-medium">{v.name}</span>
+          <span className="text-xs text-muted-foreground">{v.description}</span>
+        </div>
+      ))}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Replace text-only rendering of Navigation, Wireframes and Component Library sections in UX Plan with schematic SVG wireframes and real UI component previews
- Navigation patterns (sidebar, bottom bar, tabs, breadcrumbs) render as SVG wireframes
- Screen wireframes show layout-specific schematics (sidebar, grid, list, form, mobile)
- Component library renders real buttons, badges, cards and inputs with variant-aware styling
- Includes UX specification document and HTML/CSS mockups

Closes #39

## Test plan
- [ ] `npm test` — 288 tests passing
- [ ] `npm run lint` — no errors
- [ ] Visual: UX Plan sections render SVG wireframes for navigation patterns
- [ ] Visual: Wireframes show layout-specific schematics based on `layout` field
- [ ] Visual: Component library shows real buttons, badges, cards, inputs
- [ ] Fallback: Unknown types still render text descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)