### PR TITLE
feat(ui): add projectName prop to DevelopmentActivityPanel, rename title

### DIFF
--- a/docs/specifications/generation.feature
+++ b/docs/specifications/generation.feature
@@ -96,7 +96,7 @@ Funcionalidade: Fase de Geracao de Codigo
   Cenário: Status GENERATING stale com run terminal não exige confirmação
     Dado que o projeto está com status "GENERATING"
     E a última run está em status terminal "CANCELED"
-    Quando o usuário visualiza o painel "Pipeline Autônomo"
+    Quando o usuário visualiza o painel de construção do projeto
     Então o sistema NÃO exibe "Aguardando confirmação"
     E exibe o botão "Iniciar nova run"
     E sincroniza o status macro do projeto para "FAILED"
@@ -112,7 +112,7 @@ Funcionalidade: Fase de Geracao de Codigo
   Cenário: Painel de pipeline exibe execução com estado consistente
     Dado que a execução do pipeline autônomo está habilitada
     E existe uma run finalizada com status "SUCCEEDED"
-    Quando o usuário visualiza o painel "Pipeline Autônomo"
+    Quando o usuário visualiza o painel de construção do projeto
     Então o status exibido deve ser "Concluído"
     E não deve exibir rótulos ambíguos de modo de execução
     E o usuário não deve ver data inválida na timeline
@@ -121,7 +121,7 @@ Funcionalidade: Fase de Geracao de Codigo
   @ux @run @reinicio
   Cenário: Run terminal permite iniciar nova execução sem usar console
     Dado que a última run do projeto está em status terminal ("CANCELED" ou "SUCCEEDED")
-    Quando o usuário visualiza o painel "Pipeline Autônomo"
+    Quando o usuário visualiza o painel de construção do projeto
     Então o sistema deve exibir o botão "Iniciar nova run"
     Quando o usuário clica em "Iniciar nova run"
     Então o cliente chama POST /api/projects/:id/development/runs com assessmentConfirmed=true
@@ -131,7 +131,7 @@ Funcionalidade: Fase de Geracao de Codigo
   Cenário: Run em WAITING_CHECKPOINT exige ação explícita do usuário
     Dado que existe uma run ativa com status "WAITING_CHECKPOINT"
     E a iteração atual está marcada como falha após retries
-    Quando o usuário visualiza o painel "Pipeline Autônomo"
+    Quando o usuário visualiza o painel de construção do projeto
     Então o sistema deve exibir ações de recuperação
     E devo ver os botões "Retomar checkpoint", "Tentar novamente iteração" e "Cancelar execução"
     E ao clicar em "Tentar novamente iteração" o cliente chama POST /api/projects/:id/development/runs/:runId/retry

--- a/src/app/project/[id]/project-details.tsx
+++ b/src/app/project/[id]/project-details.tsx
@@ -212,6 +212,7 @@ export function ProjectDetails({ project }: ProjectDetailsProps) {
         <DevelopmentActivityPanel
           projectId={project.id}
           projectStatus={status}
+          projectName={project.name}
           onProjectStatusChange={setStatus}
           onJourneyStateChange={setDevelopmentUiState}
         />

--- a/src/components/project/DevelopmentActivityPanel.test.tsx
+++ b/src/components/project/DevelopmentActivityPanel.test.tsx
@@ -1635,4 +1635,37 @@ describe('DevelopmentActivityPanel', () => {
 
     FEATURES.AUTONOMOUS_DEVELOPMENT_V1 = original
   })
+
+  describe('projectName prop', () => {
+    it('displays project name in title when projectName is provided', async () => {
+      mockFetch.mockResolvedValueOnce(runsResponse([]))
+
+      render(
+        <DevelopmentActivityPanel
+          projectId="proj-1"
+          projectStatus="GENERATING"
+          projectName="Meu App Incrível"
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Construindo Meu App Incrível')).toBeInTheDocument()
+      })
+    })
+
+    it('displays fallback title when projectName is not provided', async () => {
+      mockFetch.mockResolvedValueOnce(runsResponse([]))
+
+      render(
+        <DevelopmentActivityPanel
+          projectId="proj-1"
+          projectStatus="GENERATING"
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Construindo...')).toBeInTheDocument()
+      })
+    })
+  })
 })

--- a/src/components/project/DevelopmentActivityPanel.tsx
+++ b/src/components/project/DevelopmentActivityPanel.tsx
@@ -25,6 +25,7 @@ interface RunsResponse {
 interface DevelopmentActivityPanelProps {
   projectId: string
   projectStatus: string
+  projectName?: string
   onProjectStatusChange?: (status: string) => void
   onJourneyStateChange?: (state: 'awaiting_confirmation' | 'monitoring') => void
 }
@@ -182,6 +183,7 @@ function extractErrorMessage(payload: unknown, fallback: string): string {
 export function DevelopmentActivityPanel({
   projectId,
   projectStatus,
+  projectName,
   onProjectStatusChange,
   onJourneyStateChange,
 }: DevelopmentActivityPanelProps) {
@@ -679,10 +681,9 @@ export function DevelopmentActivityPanel({
       <div className="mx-auto max-w-5xl">
         <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
           <div>
-            <h3 className="text-sm font-semibold text-slate-900">Pipeline Autônomo</h3>
-            <p className="text-xs text-slate-600">
-              Feedback em tempo real dos agentes e quality gates
-            </p>
+            <h3 className="text-sm font-semibold text-slate-900">
+              {projectName ? `Construindo ${projectName}` : 'Construindo...'}
+            </h3>
           </div>
 
           {requiresResumeConfirmation ? (


### PR DESCRIPTION
## Summary
- Add optional `projectName` prop to `DevelopmentActivityPanel` interface
- Change title from "Pipeline Autônomo" to "Construindo {projectName}"
- Remove redundant subtitle "Feedback em tempo real dos agentes e quality gates"
- Pass `projectName={project.name}` from `project-details.tsx`

## Test plan
- [x] All 33 existing tests in DevelopmentActivityPanel.test.tsx pass
- [x] Lint passes with no warnings
- [x] Manual verification: title displays "Construindo {projectName}" or "Construindo..." fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)