### PR TITLE
feat(ui): fix WAITING_CHECKPOINT badge label, add sub-gates inline

### DIFF
--- a/src/components/project/DevelopmentActivityPanel.test.tsx
+++ b/src/components/project/DevelopmentActivityPanel.test.tsx
@@ -906,7 +906,7 @@ describe('DevelopmentActivityPanel', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByText('Aguardando checkpoint')).toBeInTheDocument()
+      expect(screen.getByText('Aguardando ação')).toBeInTheDocument()
     })
 
     const source = MockEventSource.latest()
@@ -998,7 +998,7 @@ describe('DevelopmentActivityPanel', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByText('Aguardando checkpoint')).toBeInTheDocument()
+      expect(screen.getByText('Aguardando ação')).toBeInTheDocument()
     })
 
     const source = MockEventSource.latest()


### PR DESCRIPTION
## Summary
- Change WAITING_CHECKPOINT badge from "Aguardando checkpoint" to "Aguardando ação"
- Add sub-gates inline inside "Verificando qualidade" step when it has results
- Show individual gate results (BUILD ✗, UNIT skipped, etc.) nested under the step

## Test plan
- [x] All 30 tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)