### PR TITLE
fix(ux): Onda 1 - Confiança e Clareza

### DIFF
--- a/src/components/project/WorkspacePanel.tsx
+++ b/src/components/project/WorkspacePanel.tsx
@@ -380,6 +380,14 @@ function PlanningWorkspace({
 }) {
   const activePlan = getActivePlanPhase(businessPlanApproved, technicalPlanApproved)
 
+  // Issue #57: Scroll to top when active plan changes
+  useEffect(() => {
+    const container = document.querySelector('.overflow-y-auto')
+    if (container && typeof container.scrollTo === 'function') {
+      container.scrollTo({ top: 0, behavior: 'smooth' })
+    }
+  }, [activePlan])
+
   // Sub-phase breadcrumb
   const SUB_PHASES = [
     { key: 'business', label: 'Plano de Negócio', state: businessPlanApproved ? 'completed' : activePlan === 'business' ? 'active' : 'blocked' },
@@ -463,20 +471,36 @@ const UX_PLAN_STEPS = [
   'Finalizando Plano de UX...',
 ]
 
+// Issue #61: Technical Plan steps
+const TECHNICAL_PLAN_STEPS = [
+  'Analisando arquitetura...',
+  'Definindo stack tecnológica...',
+  'Planejando banco de dados...',
+  'Criando endpoints da API...',
+  'Configurando autenticação...',
+  'Definindo segurança...',
+  'Otimizando performance...',
+  'Finalizando Plano Técnico...',
+]
+
 function PlanGenerationOverlay({ activePlan }: { activePlan: string }) {
-  const isUxGeneration = activePlan === 'technical'
+  const isUxGeneration = activePlan === 'ux'
+  const isTechnicalGeneration = activePlan === 'technical'
+  const showSteps = isUxGeneration || isTechnicalGeneration
+  const steps = isUxGeneration ? UX_PLAN_STEPS : TECHNICAL_PLAN_STEPS
+  // Issue #61: Show appropriate message based on which plan is being generated
   const staticMessage = activePlan === 'business' ? 'Gerando Plano Técnico...' : 'Aprovando...'
   const [stepIndex, setStepIndex] = useState(0)
 
   useEffect(() => {
-    if (!isUxGeneration) return
+    if (!showSteps) return
     const interval = setInterval(() => {
-      setStepIndex((prev) => (prev < UX_PLAN_STEPS.length - 1 ? prev + 1 : prev))
+      setStepIndex((prev) => (prev < steps.length - 1 ? prev + 1 : prev))
     }, 15000)
     return () => clearInterval(interval)
-  }, [isUxGeneration])
+  }, [showSteps, steps.length])
 
-  const message = isUxGeneration ? UX_PLAN_STEPS[stepIndex] : staticMessage
+  const message = showSteps ? steps[stepIndex] : staticMessage
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
@@ -484,9 +508,9 @@ function PlanGenerationOverlay({ activePlan }: { activePlan: string }) {
         <div className="flex flex-col items-center gap-4">
           <div className="h-10 w-10 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
           <p className="text-sm font-medium text-gray-700">{message}</p>
-          {isUxGeneration && (
+          {showSteps && (
             <div className="flex gap-1">
-              {UX_PLAN_STEPS.map((_, i) => (
+              {steps.map((_, i) => (
                 <div
                   key={i}
                   className={`h-1.5 w-1.5 rounded-full transition-colors ${i <= stepIndex ? 'bg-blue-600' : 'bg-gray-200'}`}

--- a/src/lib/ai/prompts/planning.ts
+++ b/src/lib/ai/prompts/planning.ts
@@ -10,7 +10,7 @@ Para o MVP, use SEMPRE esta stack base:
 - **Backend**: Next.js API Routes, Prisma ORM
 - **Banco**: PostgreSQL (Supabase ou Neon)
 - **Auth**: Clerk
-- **Deploy**: Vercel
+- **Deploy**: Netlify
 
 Adicione tecnologias extras conforme necessario (real-time, pagamentos, maps, etc).
 
@@ -84,7 +84,7 @@ Responda com o TechnicalPlan em JSON:
       { "name": "Frontend", "technologies": ["Next.js 15", "React 19", "TypeScript", "Tailwind CSS", "shadcn/ui"] },
       { "name": "Backend", "technologies": ["Next.js API Routes", "Prisma ORM", "PostgreSQL"] },
       { "name": "Autenticacao", "technologies": ["Clerk", "OAuth (Google, GitHub)"] },
-      { "name": "Infraestrutura", "technologies": ["Vercel", "Supabase (DB)", "Uploadthing (Files)"] }
+      { "name": "Infraestrutura", "technologies": ["Netlify", "Supabase (DB)", "Uploadthing (Files)"] }
     ]
   },
   "architecture": {
@@ -129,7 +129,7 @@ Responda com o TechnicalPlan em JSON:
     "sensitiveData": [
       "Pagamentos: PCI-compliant via Stripe (nunca armazenamos card data)",
       "Senhas: Hash bcrypt gerenciado por Clerk",
-      "Variaveis de ambiente: Secrets gerenciados por Vercel"
+      "Variaveis de ambiente: Secrets gerenciados por Netlify"
     ],
     "compliance": [
       "LGPD: Consentimento explicito, direito ao esquecimento",
@@ -138,7 +138,7 @@ Responda com o TechnicalPlan em JSON:
   },
   "performance": {
     "caching": [
-      { "name": "CDN (Vercel Edge)", "description": "Assets estaticos com cache de 1 ano" },
+      { "name": "CDN (Netlify Edge)", "description": "Assets estaticos com cache de 1 ano" },
       { "name": "React Query", "description": "Client-side cache com staleTime de 30s" }
     ],
     "database": [
@@ -397,7 +397,7 @@ export interface TechnicalPlan {
   // 7. Performance
   performance: {
     caching: Array<{
-      name: string // "CDN (Vercel Edge)"
+      name: string // "CDN (Netlify Edge)"
       description: string
     }>
     database: string[] // ["Índices estratégicos...", ...]


### PR DESCRIPTION
## Resumo
Implementação das issues da Onda 1 (Confiança e Clareza)

## Issues
- Fixes #57 - Scroll para topo ao abrir plano
- Fixes #61 - Mostrar etapas na tela de espera do Plano Técnico
- Fixes #63 - Remover referências a Vercel, alinhar para Netlify

## Mudanças
- **#57**: Adiciona `useEffect` para scroll ao topo quando `activePlan` muda
- **#61**: Adiciona `TECHNICAL_PLAN_STEPS` com 8 etapas de progresso; corrige lógica do `PlanGenerationOverlay` para mostrar steps técnicos
- **#63**: Substitui "Vercel" por "Netlify" em `prompts/planning.ts` (deploy, infraestrutura, CDN, secrets)

## Test plan
- [x] Todos os 485 testes passam
- [x] Lint passa

🤖 Generated with [Claude Code](https://claude.com/claude-code)