### PR TITLE
docs(adr): ADR-0008 Stack única MVP + mensagens amigáveis

### DIFF
--- a/docs/adr/ADR-0008-stack-unica-mvp.md
+++ b/docs/adr/ADR-0008-stack-unica-mvp.md
@@ -1,0 +1,79 @@
+# ADR-0008: Stack Única para MVP
+
+## Status
+Aceito
+
+## Contexto
+
+True Coding precisa decidir se gera aplicações em múltiplas linguagens/frameworks ou foca em uma única stack.
+
+## Decisão
+
+Para o MVP, True Coding gerará **apenas** aplicações:
+- **Linguagem**: TypeScript
+- **Framework**: Next.js 15 (App Router)
+- **Banco**: PostgreSQL (via Supabase ou Neon)
+- **Deploy**: Netlify
+
+## Razão
+
+Foco em qualidade e time-to-market. Generalizar para multi-stack aumenta significativamente a complexidade antes de validar o produto.
+
+## Análise de Alternativas
+
+### Opção A: Stack Única (Escolhida)
+- **Prós**:
+  - Profundidade de conhecimento em uma stack
+  - Templates mais maduros e testados
+  - Debugging mais fácil
+  - Time-to-market mais rápido
+- **Contras**:
+  - Perde clientes que querem Python, Java, Go, etc.
+  - Limita mercado
+
+### Opção B: Multi-stack
+- **Prós**:
+  - Mercado maior
+  - Flexibilidade para clientes
+- **Contras**:
+  - Complexidade alta desde o início
+  - Manutenção dispersa entre stacks
+  - Qualidade pode ser inconsistente
+
+## O que Mudaria se Fosse Multi-stack
+
+| Aspecto | Stack Única | Multi-stack |
+|---------|-------------|-------------|
+| Templates | `templates/nextjs-basic/` | + `templates/python-fastapi/`, `templates/java-spring/`, etc. |
+| IA Prompts | Conhece profundamente Next.js | Precisa conhecer múltiplos frameworks superficialmente |
+| Deploy | Netlify otimizado | Precisa containers, AWS, Heroku, etc. |
+| Complexidade | Baixa | Alta |
+| Manutenção | Focada em um nicho | Dispersa |
+| Quality Gates | Específicos para TypeScript/React | Diferentes para cada linguagem |
+
+## Consequências
+
+- **Positivas**:
+  - Produto mais polido para o nicho Next.js
+  - Desenvolvimento mais rápido
+  - Menos bugs por complexidade reduzida
+
+- **Negativas**:
+  - Clientes que preferem outras stacks não usarão a plataforma
+  - Aceitável para MVP - validar produto primeiro
+
+## Revisão
+
+Após validar o MVP com a stack única, avaliar demanda para:
+1. Python (FastAPI/Django)
+2. Java (Spring Boot)
+3. Go
+4. Outros frameworks frontend (Vue, Svelte)
+
+Ver issue #79 para tracking de multi-stack.
+
+## Referências
+
+- Issue #53: Campos bloqueados no editor do Plano Técnico
+- `src/lib/ai/prompts/planning.ts`: Templates de geração
+- `src/lib/codegen/templates/`: Templates de código

--- a/src/components/project/WorkspacePanel.tsx
+++ b/src/components/project/WorkspacePanel.tsx
@@ -854,6 +854,9 @@ function TechnicalPlanView({
               <strong>Relacionamentos:</strong> {techPlan.database.summary}
             </div>
           )}
+          <div className="mt-4 rounded-lg bg-amber-50 p-3 text-xs text-amber-800 dark:bg-amber-950 dark:text-amber-200">
+            💡 Atualmente oferecemos PostgreSQL, MySQL e MongoDB. Estamos avaliando suporte a outros bancos e em breve teremos mais opções disponíveis.
+          </div>
         </div>
       )}
 
@@ -1019,6 +1022,22 @@ function TechnicalPlanView({
           </div>
         </div>
       )}
+
+      {/* 9. Deploy Info */}
+      <div className="rounded-xl border bg-card p-6">
+        <h3 className="mb-4 text-lg font-semibold">🚀 Deploy</h3>
+        <div className="space-y-3">
+          <div className="rounded-lg bg-muted/50 p-3">
+            <p className="font-semibold">Netlify</p>
+            <p className="text-sm text-muted-foreground">
+              SSL automático, CDN global, preview deploys para cada PR.
+            </p>
+          </div>
+          <div className="rounded-lg bg-amber-50 p-3 text-xs text-amber-800 dark:bg-amber-950 dark:text-amber-200">
+            💡 Durante o MVP, oferecemos deploy através da Netlify. Estamos avaliando novos provedores e em breve teremos a opção de deploy em servidor personalizado.
+          </div>
+        </div>
+      </div>
 
       {/* Botões de ação */}
       {!technicalPlanApproved && (

--- a/tests/e2e/steps/planning.steps.tsx
+++ b/tests/e2e/steps/planning.steps.tsx
@@ -456,7 +456,7 @@ describe('Planning: Technical Plan - Visualização', () => {
     // E vejo informações da stack (Next.js aparece nome + descrição)
     const nextJsElements = screen.getAllByText(/Next\.js/i)
     expect(nextJsElements.length).toBeGreaterThanOrEqual(1)
-    expect(screen.getByText(/PostgreSQL/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/PostgreSQL/i).length).toBeGreaterThan(0)
   })
 
   /**


### PR DESCRIPTION
## Resumo
Issue #53: Campos do Plano Técnico

## Mudanças
- **ADR-0008**: Documenta decisão de stack única para MVP (TypeScript/Next.js/PostgreSQL)
- **Mensagem PostgreSQL**: "Atualmente oferecemos PostgreSQL... avaliando outros bancos"
- **Seção Deploy**: Adiciona info sobre Netlify + mensagem sobre futuros provedores
- **Teste**: Atualizado para aceitar múltiplos elementos "PostgreSQL"

## Issue criada
- #79: feat(platform): suporte multi-stack/multi-linguagem

## Test plan
- [x] 21 testes passam
- [x] Lint passa

🤖 Generated with [Claude Code](https://claude.com/claude-code)