### PR TITLE
fix(planning): spinner dos 3 planos alinhado ao mockup

### DIFF
--- a/docs/specifications/discovery.feature
+++ b/docs/specifications/discovery.feature
@@ -141,6 +141,14 @@ Funcionalidade: Fase de Ideação (Discovery)
       | Finalizando               | pending   |
     E vejo "Isso pode levar alguns segundos..."
 
+  @geracao @loading @regressao
+  Cenário: Overlay de geração não abre antes da confirmação
+    Dado que respondi todas as 5 perguntas
+    E a IA perguntou se pode gerar o plano
+    Quando envio uma mensagem sem confirmação de geração
+    Então NÃO vejo overlay de loading
+    E posso continuar conversando no chat
+
   @geracao @sucesso
   Cenário: Plano gerado com sucesso
     Dado que a geração do plano terminou

--- a/docs/specifications/planning.feature
+++ b/docs/specifications/planning.feature
@@ -208,7 +208,8 @@ Funcionalidade: Fase de Planejamento
   Cenário: Aprovar UX Plan e avançar para Connection
     Dado que estou visualizando o UX Plan
     Quando clico em "Aprovar e Continuar"
-    Então o projeto avança para a fase "CONNECTING"
+    Então NÃO vejo loading de geração de plano
+    E o projeto avança para a fase "CONNECTING"
     E o workspace exibe a tela de conexão GitHub
     E a sidebar mostra "Planejamento" como "completed"
     E a sidebar mostra "Conexão" como "in-progress"

--- a/mockups/project/phase-2-planning/10-generating-technical-plan.html
+++ b/mockups/project/phase-2-planning/10-generating-technical-plan.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Planejamento - Gerando Plano Técnico | True Coding</title>
+  <link rel="stylesheet" href="../../css/tokens.css">
+  <link rel="stylesheet" href="../../css/layout.css">
+  <link rel="stylesheet" href="../../css/components.css">
+  <style>
+    @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+    @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.5; } }
+
+    .loading-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.7);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 9999;
+    }
+
+    .loading-content {
+      background: var(--color-bg-primary);
+      border-radius: var(--border-radius-lg);
+      padding: var(--space-8);
+      max-width: 520px;
+      width: calc(100% - 32px);
+      text-align: center;
+      box-shadow: var(--shadow-xl);
+    }
+
+    .loading-spinner {
+      width: 64px;
+      height: 64px;
+      border: 4px solid var(--color-gray-200);
+      border-top-color: var(--color-primary);
+      border-radius: 50%;
+      margin: 0 auto var(--space-6);
+      animation: spin 1s linear infinite;
+    }
+
+    .loading-title {
+      font-size: var(--font-size-2xl);
+      font-weight: var(--font-weight-bold);
+      color: var(--color-text-primary);
+      margin-bottom: var(--space-3);
+    }
+
+    .loading-description {
+      font-size: var(--font-size-base);
+      color: var(--color-text-secondary);
+      line-height: var(--line-height-relaxed);
+      margin-bottom: var(--space-6);
+    }
+
+    .loading-steps {
+      text-align: left;
+      background: var(--color-bg-secondary);
+      border-radius: var(--border-radius-md);
+      padding: var(--space-4);
+    }
+
+    .loading-step {
+      display: flex;
+      align-items: center;
+      gap: var(--space-3);
+      padding: var(--space-2) 0;
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+    }
+
+    .loading-step.completed { color: var(--color-success); }
+    .loading-step.current { color: var(--color-primary); font-weight: var(--font-weight-medium); }
+
+    .loading-step-icon {
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 12px;
+      flex-shrink: 0;
+    }
+
+    .loading-step.completed .loading-step-icon { background: var(--color-success); color: white; }
+    .loading-step.current .loading-step-icon { background: var(--color-primary); color: white; animation: pulse 1.5s ease-in-out infinite; }
+    .loading-step.pending .loading-step-icon { background: var(--color-gray-200); color: var(--color-text-tertiary); }
+  </style>
+</head>
+<body>
+  <div class="app-layout">
+    <aside class="sidebar">
+      <div class="sidebar-header">
+        <div class="logo">
+          <div class="logo-icon">TC</div>
+          <span>True Coding</span>
+        </div>
+        <div class="project-name">Meu App Delivery</div>
+        <a href="../../dashboard/list.html" class="back-link">← Dashboard</a>
+      </div>
+      <nav class="sidebar-nav">
+        <div class="nav-section">
+          <div class="nav-section-title">FASES</div>
+          <div class="nav-item completed"><span class="phase-icon"></span><span>Ideação</span></div>
+          <a href="#" class="nav-item in-progress"><span class="phase-icon"></span><span>Planejamento</span></a>
+          <div class="nav-item blocked"><span class="phase-icon"></span><span>Conexão</span></div>
+          <div class="nav-item blocked"><span class="phase-icon"></span><span>Geração</span></div>
+          <div class="nav-item blocked"><span class="phase-icon"></span><span>Deploy</span></div>
+          <div class="nav-item blocked"><span class="phase-icon"></span><span>Online</span></div>
+        </div>
+      </nav>
+    </aside>
+
+    <main class="main-content">
+      <section class="workspace">
+        <div class="workspace-header">
+          <div class="workspace-breadcrumb">Planejamento › Gerando Plano Técnico</div>
+          <h2 class="workspace-title">Criando arquitetura técnica</h2>
+          <p class="workspace-subtitle">Definindo stack, banco e estrutura de backend/frontend.</p>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <div class="loading-overlay">
+    <div class="loading-content">
+      <div class="loading-spinner"></div>
+      <div class="loading-title">Gerando Plano Técnico...</div>
+      <div class="loading-description">
+        Montando arquitetura, stack tecnológica e estrutura técnica do projeto.
+      </div>
+      <div class="loading-steps">
+        <div class="loading-step completed"><div class="loading-step-icon">✓</div><span>Analisando arquitetura</span></div>
+        <div class="loading-step current"><div class="loading-step-icon">2</div><span>Definindo stack tecnológica</span></div>
+        <div class="loading-step pending"><div class="loading-step-icon">3</div><span>Planejando banco de dados</span></div>
+        <div class="loading-step pending"><div class="loading-step-icon">4</div><span>Criando endpoints</span></div>
+        <div class="loading-step pending"><div class="loading-step-icon">5</div><span>Finalizando plano técnico</span></div>
+      </div>
+      <p style="margin-top: var(--space-4); font-size: var(--font-size-sm); color: var(--color-text-secondary);">
+        Isso pode levar alguns segundos...
+      </p>
+    </div>
+  </div>
+
+  <div style="position: fixed; bottom: var(--space-4); left: 50%; transform: translateX(-50%); z-index: 1000;">
+    <a href="../../index.html" style="display: inline-flex; align-items: center; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: var(--color-bg-primary); border: 1px solid var(--color-border); border-radius: var(--border-radius-md); text-decoration: none; color: var(--color-text-secondary); font-size: var(--font-size-sm); box-shadow: var(--shadow-md);">← Hub</a>
+  </div>
+</body>
+</html>

--- a/mockups/project/phase-2-planning/11-generating-ux-plan.html
+++ b/mockups/project/phase-2-planning/11-generating-ux-plan.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Planejamento - Gerando Plano de UX | True Coding</title>
+  <link rel="stylesheet" href="../../css/tokens.css">
+  <link rel="stylesheet" href="../../css/layout.css">
+  <link rel="stylesheet" href="../../css/components.css">
+  <style>
+    @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+    @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.5; } }
+
+    .loading-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.7);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 9999;
+    }
+
+    .loading-content {
+      background: var(--color-bg-primary);
+      border-radius: var(--border-radius-lg);
+      padding: var(--space-8);
+      max-width: 520px;
+      width: calc(100% - 32px);
+      text-align: center;
+      box-shadow: var(--shadow-xl);
+    }
+
+    .loading-spinner {
+      width: 64px;
+      height: 64px;
+      border: 4px solid var(--color-gray-200);
+      border-top-color: var(--color-primary);
+      border-radius: 50%;
+      margin: 0 auto var(--space-6);
+      animation: spin 1s linear infinite;
+    }
+
+    .loading-title {
+      font-size: var(--font-size-2xl);
+      font-weight: var(--font-weight-bold);
+      color: var(--color-text-primary);
+      margin-bottom: var(--space-3);
+    }
+
+    .loading-description {
+      font-size: var(--font-size-base);
+      color: var(--color-text-secondary);
+      line-height: var(--line-height-relaxed);
+      margin-bottom: var(--space-6);
+    }
+
+    .loading-steps {
+      text-align: left;
+      background: var(--color-bg-secondary);
+      border-radius: var(--border-radius-md);
+      padding: var(--space-4);
+    }
+
+    .loading-step {
+      display: flex;
+      align-items: center;
+      gap: var(--space-3);
+      padding: var(--space-2) 0;
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
+    }
+
+    .loading-step.completed { color: var(--color-success); }
+    .loading-step.current { color: var(--color-primary); font-weight: var(--font-weight-medium); }
+
+    .loading-step-icon {
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 12px;
+      flex-shrink: 0;
+    }
+
+    .loading-step.completed .loading-step-icon { background: var(--color-success); color: white; }
+    .loading-step.current .loading-step-icon { background: var(--color-primary); color: white; animation: pulse 1.5s ease-in-out infinite; }
+    .loading-step.pending .loading-step-icon { background: var(--color-gray-200); color: var(--color-text-tertiary); }
+  </style>
+</head>
+<body>
+  <div class="app-layout">
+    <aside class="sidebar">
+      <div class="sidebar-header">
+        <div class="logo">
+          <div class="logo-icon">TC</div>
+          <span>True Coding</span>
+        </div>
+        <div class="project-name">Meu App Delivery</div>
+        <a href="../../dashboard/list.html" class="back-link">← Dashboard</a>
+      </div>
+      <nav class="sidebar-nav">
+        <div class="nav-section">
+          <div class="nav-section-title">FASES</div>
+          <div class="nav-item completed"><span class="phase-icon"></span><span>Ideação</span></div>
+          <a href="#" class="nav-item in-progress"><span class="phase-icon"></span><span>Planejamento</span></a>
+          <div class="nav-item blocked"><span class="phase-icon"></span><span>Conexão</span></div>
+          <div class="nav-item blocked"><span class="phase-icon"></span><span>Geração</span></div>
+          <div class="nav-item blocked"><span class="phase-icon"></span><span>Deploy</span></div>
+          <div class="nav-item blocked"><span class="phase-icon"></span><span>Online</span></div>
+        </div>
+      </nav>
+    </aside>
+
+    <main class="main-content">
+      <section class="workspace">
+        <div class="workspace-header">
+          <div class="workspace-breadcrumb">Planejamento › Gerando Plano de UX</div>
+          <h2 class="workspace-title">Criando experiência do usuário</h2>
+          <p class="workspace-subtitle">Definindo personas, jornadas, wireframes e design tokens.</p>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <div class="loading-overlay">
+    <div class="loading-content">
+      <div class="loading-spinner"></div>
+      <div class="loading-title">Gerando Plano de UX...</div>
+      <div class="loading-description">
+        Organizando a experiência do produto com foco em usabilidade e clareza.
+      </div>
+      <div class="loading-steps">
+        <div class="loading-step completed"><div class="loading-step-icon">✓</div><span>Analisando requisitos</span></div>
+        <div class="loading-step current"><div class="loading-step-icon">2</div><span>Definindo personas</span></div>
+        <div class="loading-step pending"><div class="loading-step-icon">3</div><span>Mapeando jornadas</span></div>
+        <div class="loading-step pending"><div class="loading-step-icon">4</div><span>Estruturando wireframes</span></div>
+        <div class="loading-step pending"><div class="loading-step-icon">5</div><span>Finalizando plano de UX</span></div>
+      </div>
+      <p style="margin-top: var(--space-4); font-size: var(--font-size-sm); color: var(--color-text-secondary);">
+        Isso pode levar alguns segundos...
+      </p>
+    </div>
+  </div>
+
+  <div style="position: fixed; bottom: var(--space-4); left: 50%; transform: translateX(-50%); z-index: 1000;">
+    <a href="../../index.html" style="display: inline-flex; align-items: center; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: var(--color-bg-primary); border: 1px solid var(--color-border); border-radius: var(--border-radius-md); text-decoration: none; color: var(--color-text-secondary); font-size: var(--font-size-sm); box-shadow: var(--shadow-md);">← Hub</a>
+  </div>
+</body>
+</html>

--- a/src/components/project/ChatPanel.tsx
+++ b/src/components/project/ChatPanel.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { useUser } from '@clerk/nextjs'
 import { useProjectLayout } from './ProjectLayout'
+import { PlanGenerationOverlay } from './PlanGenerationOverlay'
 import { FEATURES } from '@/config/features'
 import { QUICK_REPLIES_BY_QUESTION } from '@/types'
 
@@ -39,6 +40,23 @@ function stripJsonFromDisplay(content: string): string {
   result = result.replace(/\{[\s\S]*"(coreFeatures|name|tagline|targetAudience)"[\s\S]*\}/g, '')
 
   return result.trim()
+}
+
+function isPlanGenerationConfirmationMessage(content: string): boolean {
+  const normalized = content.trim().toLowerCase()
+  if (!normalized) return false
+
+  const patterns = [
+    /^sim[\s!.,?]*$/,
+    /^ok[\s!.,?]*$/,
+    /^pode[\s!.,?]*$/,
+    /confirm/i,
+    /ger(ar|e)\s+(o\s+)?plano/i,
+    /pode\s+(gerar|criar)/i,
+    /seguir\s+com\s+o\s+plano/i,
+  ]
+
+  return patterns.some((pattern) => pattern.test(normalized))
 }
 
 interface QuestionProgress {
@@ -110,6 +128,13 @@ export function ChatPanel({
   const sendMessage = async (content: string) => {
     if (!content.trim() || isLoading) return
 
+    const completedCount = questionProgress?.completedQuestions?.length || 0
+    const isConfirmationPhase = completedCount >= 5
+    const shouldStartPlanGeneration =
+      isConfirmationPhase &&
+      !planReady &&
+      isPlanGenerationConfirmationMessage(content)
+
     const userMessage: Message = {
       id: crypto.randomUUID(),
       role: 'user',
@@ -119,6 +144,7 @@ export function ChatPanel({
     setMessages((prev) => [...prev, userMessage])
     setInput('')
     setIsLoading(true)
+    setIsGeneratingPlan(shouldStartPlanGeneration)
 
     try {
       const response = await fetch('/api/chat', {
@@ -187,10 +213,6 @@ export function ChatPanel({
                 setQuestionProgress(parsed.progress)
                 // Notify parent component
                 onProgressUpdate?.(parsed.progress)
-                // Check if this is question 5 (last question before plan generation)
-                if (parsed.progress.current === 5) {
-                  setIsGeneratingPlan(true)
-                }
               } else if (currentEvent === 'plan_ready' && parsed.plan) {
                 console.log('[CHAT] Plan ready detected! Plan:', parsed.plan)
                 setIsGeneratingPlan(false)
@@ -434,22 +456,7 @@ export function ChatPanel({
         </div>
       </div>
 
-      {/* Loading Overlay - Plan Generation */}
-      {isGeneratingPlan && (
-        <div className="absolute inset-0 z-50 flex items-center justify-center bg-white/80 backdrop-blur-sm">
-          <div className="rounded-lg border bg-white p-6 shadow-lg">
-            <div className="flex flex-col items-center gap-4">
-              <div className="h-12 w-12 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
-              <div className="text-center">
-                <h3 className="font-semibold text-gray-900">Gerando Business Plan...</h3>
-                <p className="mt-1 text-sm text-gray-500">
-                  Isso pode levar alguns segundos
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+      <PlanGenerationOverlay kind="business" visible={isGeneratingPlan} />
     </div>
   )
 }

--- a/src/components/project/PlanGenerationOverlay.tsx
+++ b/src/components/project/PlanGenerationOverlay.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+
+export type PlanGenerationKind = 'business' | 'technical' | 'ux'
+
+interface PlanLoadingConfig {
+  title: string
+  description: string
+  steps: string[]
+}
+
+const PLAN_LOADING_CONFIG: Record<PlanGenerationKind, PlanLoadingConfig> = {
+  business: {
+    title: 'Gerando Plano de Negócio...',
+    description: 'Analisando suas respostas e estruturando um plano completo.',
+    steps: [
+      'Analisando respostas',
+      'Estruturando plano',
+      'Definindo features',
+      'Finalizando',
+    ],
+  },
+  technical: {
+    title: 'Gerando Plano Técnico...',
+    description: 'Montando arquitetura, stack e estrutura técnica do projeto.',
+    steps: [
+      'Analisando arquitetura',
+      'Definindo stack tecnológica',
+      'Planejando banco de dados',
+      'Criando endpoints',
+      'Finalizando plano técnico',
+    ],
+  },
+  ux: {
+    title: 'Gerando Plano de UX...',
+    description: 'Definindo personas, jornadas e estrutura de interface.',
+    steps: [
+      'Analisando requisitos',
+      'Definindo personas',
+      'Mapeando jornadas',
+      'Estruturando wireframes',
+      'Finalizando plano de UX',
+    ],
+  },
+}
+
+interface PlanGenerationOverlayProps {
+  kind: PlanGenerationKind
+  visible: boolean
+}
+
+function getInitialCurrentStep(totalSteps: number): number {
+  if (totalSteps <= 1) return 0
+  return 1
+}
+
+export function PlanGenerationOverlay({
+  kind,
+  visible,
+}: PlanGenerationOverlayProps) {
+  const config = PLAN_LOADING_CONFIG[kind]
+
+  const initialStep = useMemo(
+    () => getInitialCurrentStep(config.steps.length),
+    [config.steps.length]
+  )
+  const [currentStep, setCurrentStep] = useState(initialStep)
+
+  useEffect(() => {
+    if (!visible) return
+
+    setCurrentStep(initialStep)
+
+    const interval = setInterval(() => {
+      setCurrentStep((previous) => {
+        if (previous >= config.steps.length - 1) return previous
+        return previous + 1
+      })
+    }, 2000)
+
+    return () => clearInterval(interval)
+  }, [visible, initialStep, config.steps.length])
+
+  if (!visible) return null
+
+  return (
+    <div
+      data-testid="plan-generation-overlay"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <div className="w-full max-w-lg rounded-xl bg-white p-8 shadow-2xl">
+        <div className="flex flex-col items-center">
+          <div className="mb-5 h-16 w-16 animate-spin rounded-full border-4 border-gray-200 border-t-blue-600" />
+          <h3 className="mb-2 text-center text-2xl font-bold text-gray-900">
+            {config.title}
+          </h3>
+          <p className="mb-6 text-center text-sm text-gray-600">
+            {config.description}
+          </p>
+        </div>
+
+        <div className="rounded-lg bg-gray-50 p-4">
+          <ul className="space-y-3">
+            {config.steps.map((step, index) => {
+              const status =
+                index < currentStep
+                  ? 'completed'
+                  : index === currentStep
+                    ? 'current'
+                    : 'pending'
+
+              return (
+                <li key={step} className="flex items-center gap-3">
+                  {status === 'completed' && (
+                    <div className="flex h-5 w-5 items-center justify-center rounded-full bg-green-600 text-xs font-semibold text-white">
+                      ✓
+                    </div>
+                  )}
+                  {status === 'current' && (
+                    <div className="flex h-5 w-5 items-center justify-center rounded-full bg-blue-600 text-xs font-semibold text-white">
+                      {index + 1}
+                    </div>
+                  )}
+                  {status === 'pending' && (
+                    <div className="flex h-5 w-5 items-center justify-center rounded-full bg-gray-200 text-xs font-semibold text-gray-500">
+                      {index + 1}
+                    </div>
+                  )}
+                  <span
+                    className={
+                      status === 'completed'
+                        ? 'text-sm font-medium text-green-700'
+                        : status === 'current'
+                          ? 'text-sm font-medium text-blue-700'
+                          : 'text-sm text-gray-500'
+                    }
+                  >
+                    {step}
+                  </span>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+
+        <p className="mt-4 text-center text-sm text-gray-500">
+          Isso pode levar alguns segundos...
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/project/WorkspacePanel.tsx
+++ b/src/components/project/WorkspacePanel.tsx
@@ -4,6 +4,10 @@ import { useState, useEffect } from 'react'
 import { useProjectLayout } from './ProjectLayout'
 import { ConnectionPhase } from './phases/ConnectionPhase'
 import { GenerationProgress } from './GenerationProgress'
+import {
+  PlanGenerationOverlay,
+  type PlanGenerationKind,
+} from './PlanGenerationOverlay'
 import { FEATURES } from '@/config/features'
 
 // Parse business plan from JSON string
@@ -350,6 +354,12 @@ function getActivePlanPhase(businessPlanApproved: boolean, technicalPlanApproved
   return 'ux'
 }
 
+function getNextPlanGenerationKind(activePlan: 'business' | 'technical' | 'ux'): PlanGenerationKind | null {
+  if (activePlan === 'business') return 'technical'
+  if (activePlan === 'technical') return 'ux'
+  return null
+}
+
 // Phase: PLANNING — renders only the current active sub-plan
 function PlanningWorkspace({
   businessPlan,
@@ -379,6 +389,7 @@ function PlanningWorkspace({
   isApproving?: boolean
 }) {
   const activePlan = getActivePlanPhase(businessPlanApproved, technicalPlanApproved)
+  const nextPlanKind = getNextPlanGenerationKind(activePlan)
 
   // Issue #57: Scroll to top when active plan changes
   useEffect(() => {
@@ -450,75 +461,10 @@ function PlanningWorkspace({
         )}
 
         {/* Loading overlay while generating next plan */}
-        {isApproving && (
-          <PlanGenerationOverlay activePlan={activePlan} />
-        )}
-      </div>
-    </div>
-  )
-}
-
-// Progressive loading overlay for plan generation
-const UX_PLAN_STEPS = [
-  'Analisando requisitos...',
-  'Criando Personas...',
-  'Definindo Arquitetura de Informação...',
-  'Planejando Jornadas de Usuário...',
-  'Criando Wireframes...',
-  'Montando Biblioteca de Componentes...',
-  'Definindo Acessibilidade...',
-  'Gerando Design Tokens...',
-  'Finalizando Plano de UX...',
-]
-
-// Issue #61: Technical Plan steps
-const TECHNICAL_PLAN_STEPS = [
-  'Analisando arquitetura...',
-  'Definindo stack tecnológica...',
-  'Planejando banco de dados...',
-  'Criando endpoints da API...',
-  'Configurando autenticação...',
-  'Definindo segurança...',
-  'Otimizando performance...',
-  'Finalizando Plano Técnico...',
-]
-
-function PlanGenerationOverlay({ activePlan }: { activePlan: string }) {
-  const isUxGeneration = activePlan === 'ux'
-  const isTechnicalGeneration = activePlan === 'technical'
-  const showSteps = isUxGeneration || isTechnicalGeneration
-  const steps = isUxGeneration ? UX_PLAN_STEPS : TECHNICAL_PLAN_STEPS
-  // Issue #61: Show appropriate message based on which plan is being generated
-  const staticMessage = activePlan === 'business' ? 'Gerando Plano Técnico...' : 'Aprovando...'
-  const [stepIndex, setStepIndex] = useState(0)
-
-  useEffect(() => {
-    if (!showSteps) return
-    const interval = setInterval(() => {
-      setStepIndex((prev) => (prev < steps.length - 1 ? prev + 1 : prev))
-    }, 15000)
-    return () => clearInterval(interval)
-  }, [showSteps, steps.length])
-
-  const message = showSteps ? steps[stepIndex] : staticMessage
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
-      <div className="rounded-lg border bg-white p-8 shadow-lg">
-        <div className="flex flex-col items-center gap-4">
-          <div className="h-10 w-10 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
-          <p className="text-sm font-medium text-gray-700">{message}</p>
-          {showSteps && (
-            <div className="flex gap-1">
-              {steps.map((_, i) => (
-                <div
-                  key={i}
-                  className={`h-1.5 w-1.5 rounded-full transition-colors ${i <= stepIndex ? 'bg-blue-600' : 'bg-gray-200'}`}
-                />
-              ))}
-            </div>
-          )}
-        </div>
+        <PlanGenerationOverlay
+          kind={nextPlanKind ?? 'technical'}
+          visible={Boolean(isApproving && nextPlanKind)}
+        />
       </div>
     </div>
   )

--- a/tests/e2e/steps/discovery.steps.tsx
+++ b/tests/e2e/steps/discovery.steps.tsx
@@ -800,6 +800,79 @@ describe('Discovery: Loading States', () => {
 
     expect(screen.getByText('Plano pronto')).toBeInTheDocument()
   })
+
+  /**
+   * @geracao @loading
+   * Cenário: Overlay de geração abre somente após confirmação explícita
+   */
+  it('Exibe overlay de geração quando usuário confirma na fase de confirmação', async () => {
+    global.fetch = vi.fn().mockImplementation(
+      () =>
+        new Promise(() => {
+          // Mantém request pendente para validar estado de loading visível.
+        })
+    )
+
+    render(
+      <ChatPanel
+        projectId="test"
+        projectName="Test"
+        initialPlanReady={false}
+        initialQuestionProgress={{
+          current: 5,
+          total: 5,
+          completedQuestions: [1, 2, 3, 4, 5],
+        }}
+        initialMessages={[]}
+      />
+    )
+
+    const textarea = screen.getByPlaceholderText('Digite sua resposta...')
+    await userEvent.type(textarea, 'Sim')
+    await userEvent.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('plan-generation-overlay')).toBeInTheDocument()
+      expect(screen.getByText('Gerando Plano de Negócio...')).toBeInTheDocument()
+    })
+  })
+
+  /**
+   * @geracao @loading @regressao
+   * Cenário: Overlay não abre sem confirmação explícita
+   */
+  it('Não exibe overlay de geração sem confirmação explícita', async () => {
+    global.fetch = vi.fn().mockImplementation(
+      () =>
+        new Promise(() => {
+          // Mantém request pendente para validar que o overlay não abriu por engano.
+        })
+    )
+
+    render(
+      <ChatPanel
+        projectId="test"
+        projectName="Test"
+        initialPlanReady={false}
+        initialQuestionProgress={{
+          current: 5,
+          total: 5,
+          completedQuestions: [1, 2, 3, 4, 5],
+        }}
+        initialMessages={[]}
+      />
+    )
+
+    const textarea = screen.getByPlaceholderText('Digite sua resposta...')
+    await userEvent.type(textarea, 'Quero revisar mais um ponto')
+    await userEvent.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('plan-generation-overlay')
+      ).not.toBeInTheDocument()
+    })
+  })
 })
 
 /**

--- a/tests/e2e/steps/planning.steps.tsx
+++ b/tests/e2e/steps/planning.steps.tsx
@@ -676,6 +676,28 @@ describe('Planning: Technical Plan - Aprovação', () => {
     // Então o callback é chamado
     expect(onApproveTechnicalPlan).toHaveBeenCalledTimes(1)
   })
+
+  /**
+   * @technical-plan @aprovacao @loading
+   * Cenário: isApproving=true no plano técnico exibe loading do Plano de UX
+   */
+  it('Exibe overlay "Gerando Plano de UX..." quando technical está em aprovação', () => {
+    render(
+      <WorkspacePanel
+        projectId="test-project"
+        projectName="Meu App Delivery"
+        status="PLANNING"
+        businessPlan={sampleBusinessPlan}
+        businessPlanApproved={true}
+        technicalPlan={sampleTechnicalPlan}
+        technicalPlanApproved={false}
+        isApproving={true}
+      />
+    )
+
+    expect(screen.getByTestId('plan-generation-overlay')).toBeInTheDocument()
+    expect(screen.getByText('Gerando Plano de UX...')).toBeInTheDocument()
+  })
 })
 
 // Sample UX Plan for tests - nova estrutura baseada no mockup 07-ux-plan.html
@@ -890,5 +912,31 @@ describe('Planning: UX Plan - Aprovação', () => {
 
     // Então o callback é chamado
     expect(onApproveUxPlan).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * @ux-plan @aprovacao @loading
+   * Cenário: UX em aprovação não exibe loading de geração de plano
+   */
+  it('Não exibe overlay de geração quando UX está em aprovação', () => {
+    render(
+      <WorkspacePanel
+        projectId="test-project"
+        projectName="Meu App Delivery"
+        status="PLANNING"
+        businessPlan={sampleBusinessPlan}
+        businessPlanApproved={true}
+        technicalPlan={sampleTechnicalPlan}
+        technicalPlanApproved={true}
+        uxPlan={sampleUxPlan}
+        uxPlanApproved={false}
+        isApproving={true}
+      />
+    )
+
+    expect(
+      screen.queryByTestId('plan-generation-overlay')
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText('Gerando Plano de UX...')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Objetivo
Implementar o spinner dos 3 planos no padrão do mockup e corrigir os gatilhos de loading no fluxo de planning/discovery.

Closes #81

## O que mudou
- criou `PlanGenerationOverlay` compartilhado para `business`, `technical` e `ux`
- `ChatPanel`: loading do business inicia apenas após confirmação explícita
- `WorkspacePanel`: loading mapeado corretamente (`business -> technical`, `technical -> ux`, `ux -> sem loading`)
- adicionou mockups de loading para plano técnico e UX
- atualizou Gherkin + testes de regressão para comportamento de overlay

## Validação
- `npm test`
- `npm run lint`
