### PR TITLE
feat(brand): logo SVG + favicon + componente <Logo> (TRC-14.2)

### DIFF
--- a/public/brand/logo-mark.svg
+++ b/public/brand/logo-mark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" width="80" height="80" role="img" aria-label="True Coding">
+  <circle cx="40" cy="40" r="36" fill="none" stroke="#2563eb" stroke-width="3"></circle>
+  <path d="M28 26 L44 40 L28 54" fill="none" stroke="#2563eb" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"></path>
+  <path d="M40 26 L56 40 L40 54" fill="none" stroke="#2563eb" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"></path>
+</svg>

--- a/public/brand/logo-wordmark.svg
+++ b/public/brand/logo-wordmark.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 80" width="320" height="80" role="img" aria-label="True Coding">
+  <circle cx="40" cy="40" r="32" fill="none" stroke="#2563eb" stroke-width="2.5"></circle>
+  <path d="M30 28 L44 40 L30 52" fill="none" stroke="#2563eb" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"></path>
+  <path d="M41 28 L55 40 L41 52" fill="none" stroke="#2563eb" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"></path>
+  <text x="86" y="50" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif" font-size="26" font-weight="600" letter-spacing="-0.4" fill="#111827">true<tspan fill="#2563eb">coding</tspan></text>
+</svg>

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" width="80" height="80" role="img" aria-label="True Coding">
+  <circle cx="40" cy="40" r="36" fill="none" stroke="#2563eb" stroke-width="3"></circle>
+  <path d="M28 26 L44 40 L28 54" fill="none" stroke="#2563eb" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"></path>
+  <path d="M40 26 L56 40 L40 54" fill="none" stroke="#2563eb" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"></path>
+</svg>

--- a/src/components/brand/Logo.test.tsx
+++ b/src/components/brand/Logo.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Logo } from './Logo'
+
+describe('Logo', () => {
+  it('renderiza o mark por padrao com aria-label "True Coding"', () => {
+    render(<Logo />)
+    const svg = screen.getByRole('img', { name: 'True Coding' })
+    expect(svg).toBeInTheDocument()
+    expect(svg.getAttribute('viewBox')).toBe('0 0 80 80')
+  })
+
+  it('usa tamanho default de 24 para mark quando size nao informado', () => {
+    render(<Logo />)
+    const svg = screen.getByRole('img', { name: 'True Coding' })
+    expect(svg.getAttribute('width')).toBe('24')
+    expect(svg.getAttribute('height')).toBe('24')
+  })
+
+  it('aplica size customizado mantendo proporcao quadrada no mark', () => {
+    render(<Logo variant="mark" size={48} />)
+    const svg = screen.getByRole('img', { name: 'True Coding' })
+    expect(svg.getAttribute('width')).toBe('48')
+    expect(svg.getAttribute('height')).toBe('48')
+  })
+
+  it('renderiza o wordmark com viewBox 0 0 320 80 e proporcao 4:1', () => {
+    render(<Logo variant="wordmark" size={160} />)
+    const svg = screen.getByRole('img', { name: 'True Coding' })
+    expect(svg.getAttribute('viewBox')).toBe('0 0 320 80')
+    expect(svg.getAttribute('width')).toBe('160')
+    expect(svg.getAttribute('height')).toBe('40')
+  })
+
+  it('aceita aria-label customizado para contextos especificos', () => {
+    render(<Logo aria-label="Ir para o dashboard" />)
+    expect(
+      screen.getByRole('img', { name: 'Ir para o dashboard' })
+    ).toBeInTheDocument()
+  })
+
+  it('propaga className para o svg', () => {
+    render(<Logo className="h-6 w-6" />)
+    const svg = screen.getByRole('img', { name: 'True Coding' })
+    expect(svg).toHaveClass('h-6', 'w-6')
+  })
+})

--- a/src/components/brand/Logo.tsx
+++ b/src/components/brand/Logo.tsx
@@ -1,0 +1,132 @@
+/**
+ * TRC-14.2 — Componente de marca True Coding.
+ *
+ * Renderiza o logo inline como <svg> (e nao via <img>) para:
+ *   - permitir styling via tokens/currentColor se necessario no futuro;
+ *   - evitar flash durante load;
+ *   - servir como unica fonte de marca em toda a UI.
+ *
+ * Os paths espelham 1:1 os arquivos originais do mockup em
+ * `Spec/Jornada Coleta inicial/assets/logo-{mark,wordmark}.svg`. A cor da marca
+ * (#2563eb) esta hardcoded aqui porque a marca NAO deve mudar com o tema; se
+ * algum dia quisermos alternar, trocamos por `currentColor` e aplicamos via
+ * className.
+ */
+
+type LogoVariant = 'mark' | 'wordmark'
+
+type LogoProps = {
+  variant?: LogoVariant
+  /** Largura em px. Altura mantem a proporcao do viewBox. */
+  size?: number
+  className?: string
+  'aria-label'?: string
+}
+
+const BRAND_PRIMARY = '#2563eb'
+const INK = '#111827'
+
+const DEFAULT_SIZE: Record<LogoVariant, number> = {
+  mark: 24,
+  wordmark: 120,
+}
+
+export function Logo({
+  variant = 'mark',
+  size,
+  className,
+  'aria-label': ariaLabel = 'True Coding',
+}: LogoProps) {
+  const width = size ?? DEFAULT_SIZE[variant]
+
+  if (variant === 'wordmark') {
+    // Proporcao 320:80 = 4:1
+    const height = width / 4
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 320 80"
+        width={width}
+        height={height}
+        role="img"
+        aria-label={ariaLabel}
+        className={className}
+      >
+        <circle
+          cx="40"
+          cy="40"
+          r="32"
+          fill="none"
+          stroke={BRAND_PRIMARY}
+          strokeWidth="2.5"
+        />
+        <path
+          d="M30 28 L44 40 L30 52"
+          fill="none"
+          stroke={BRAND_PRIMARY}
+          strokeWidth="6"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M41 28 L55 40 L41 52"
+          fill="none"
+          stroke={BRAND_PRIMARY}
+          strokeWidth="6"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <text
+          x="86"
+          y="50"
+          fontFamily="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif"
+          fontSize="26"
+          fontWeight="600"
+          letterSpacing="-0.4"
+          fill={INK}
+        >
+          true
+          <tspan fill={BRAND_PRIMARY}>coding</tspan>
+        </text>
+      </svg>
+    )
+  }
+
+  // mark — proporcao 80:80 = 1:1
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 80 80"
+      width={width}
+      height={width}
+      role="img"
+      aria-label={ariaLabel}
+      className={className}
+    >
+      <circle
+        cx="40"
+        cy="40"
+        r="36"
+        fill="none"
+        stroke={BRAND_PRIMARY}
+        strokeWidth="3"
+      />
+      <path
+        d="M28 26 L44 40 L28 54"
+        fill="none"
+        stroke={BRAND_PRIMARY}
+        strokeWidth="7"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M40 26 L56 40 L40 54"
+        fill="none"
+        stroke={BRAND_PRIMARY}
+        strokeWidth="7"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -2,6 +2,7 @@
 
 import { useUser } from '@clerk/nextjs'
 import Link from 'next/link'
+import { Logo } from '@/components/brand/Logo'
 
 export function DashboardHeader() {
   const { user } = useUser()
@@ -17,9 +18,7 @@ export function DashboardHeader() {
     <header className="flex items-center justify-between border-b bg-white px-8 py-5">
       {/* Logo */}
       <Link href="/dashboard" className="flex items-center gap-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-600 text-xl font-bold text-white">
-          TC
-        </div>
+        <Logo variant="mark" size={40} />
         <span className="text-xl font-bold text-blue-600">True Coding</span>
       </Link>
 

--- a/src/components/project/ProjectSidebar.tsx
+++ b/src/components/project/ProjectSidebar.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { useUser } from '@clerk/nextjs'
+import { Logo } from '@/components/brand/Logo'
 import { useProjectLayout } from './ProjectLayout'
 
 // Phase configuration matching the mockup
@@ -90,9 +91,7 @@ export function ProjectSidebar({
       <div className="border-b p-5">
         {/* Logo */}
         <div className="mb-4 flex items-center gap-2">
-          <div className="flex h-7 w-7 items-center justify-center rounded-md bg-blue-600 text-xs font-bold text-white">
-            TC
-          </div>
+          <Logo variant="mark" size={28} />
           <span className="text-lg font-bold text-blue-600">True Coding</span>
         </div>
 


### PR DESCRIPTION
## Summary

Substitui o placeholder textual "TC" pelo logo SVG oficial do mockup em todos os pontos visíveis. Adiciona componente `<Logo>` reutilizável e favicon via convenção do Next App Router.

Parte do épico **TRC-14 Fundação**. Destrava TRC-14.4 (sidebar) que consome o Logo.

Notion: [TRC-14.2](https://www.notion.so/34b0d9578db381ce97fed0aa8131d646) · [TRC-14 (épico pai)](https://www.notion.so/34b0d9578db3813e860ecacb4a83055e)

## Escopo

- `public/brand/logo-{mark,wordmark}.svg`: cópias exatas dos assets em `Spec/Jornada Coleta inicial/assets/`
- `src/app/icon.svg`: mesma arte do mark → favicon automático (App Router)
- `src/components/brand/Logo.tsx`: SVG inline com `variant={mark|wordmark}`, `size`, `className`, `aria-label` (default "True Coding")
- `src/components/brand/Logo.test.tsx`: 6 cenários (variants, size default/custom, proporção 4:1, aria-label, className propagation)
- `DashboardHeader.tsx`, `ProjectSidebar.tsx`: swap do `<div>TC</div>` para `<Logo>`

## Decisões

- **Cor `#2563eb` hardcoded** no componente (não `text-brand-primary`): marca é imutável vs tema + evita issue de Tailwind JIT com classes dinâmicas (lição do TRC-14.1).
- **ProjectHeader** não alterado: `"True Coding"` textual é institucional, não placeholder de logo.
- **ChatPanel** não alterado: avatar de conversation é outro contexto.
- **Apenas `src/app/icon.svg`**: cobre browsers modernos via Next. Legacy `.ico`/PNGs ficam pra outro ticket se necessário.

## Test plan

- [x] `npm run lint` (sem warnings/errors)
- [x] `npm run build` (Compiled successfully; `/icon.svg` estática)
- [x] `npm test` (507/507 passed, incluindo os 6 novos em `Logo.test.tsx`)
- [ ] Abrir `/` em dev e verificar: tab do browser mostra logo azul; dashboard e sidebar de projeto mostram o logo novo no lugar do "TC"
- [ ] Confirmar que `ProjectHeader` e `ChatPanel` não regrediram

🤖 Generated with [Claude Code](https://claude.com/claude-code)