### PR TITLE
feat(ui): primitivas Button/Chip/Dot/ProgressBar/TypingDots/Callout (TRC-14.3)

### DIFF
--- a/src/app/design-system/page.tsx
+++ b/src/app/design-system/page.tsx
@@ -1,5 +1,14 @@
 import type { Metadata } from 'next'
 
+import {
+  BrandButton,
+  Callout,
+  Chip,
+  Dot,
+  ProgressBar,
+  TypingDots,
+} from '@/components/ui'
+
 import { AnimationPlayground, FocusRingDemo } from './interactive-demos'
 
 /**
@@ -156,21 +165,169 @@ export default function DesignSystemPage() {
       <div className="mx-auto flex max-w-5xl flex-col gap-8 px-6 py-10">
         <header className="flex flex-col gap-2">
           <span className="inline-flex w-fit items-center gap-2 rounded-full bg-brand-primary-light px-3 py-1 text-xs font-medium text-brand-primary">
-            TRC-14.1
+            TRC-14.1 · TRC-14.3
           </span>
           <h1 className="text-3xl font-semibold tracking-tight text-ink">
             Design System — referência visual
           </h1>
           <p className="max-w-2xl text-sm text-ink-secondary">
-            Esta página expõe os tokens do mockup oficial
+            Esta página expõe os tokens e as primitivas do mockup oficial
             <code className="mx-1 rounded-brand-sm bg-surface-muted px-1.5 py-0.5 text-[12px] text-ink">
               /Spec/Jornada Coleta inicial/prototipo.html
             </code>
-            já disponíveis no Tailwind. Use-a para validar visualmente cores,
-            raios, sombras, animações, foco e scrollbar antes de construir as
-            primitivas em TRC-14.3.
+            já disponíveis no Tailwind e em <code>@/components/ui</code>. Use-a
+            para validar visualmente primitivas, cores, raios, sombras,
+            animações, foco e scrollbar.
           </p>
         </header>
+
+        <Section
+          id="primitivas"
+          title="Primitivas"
+          description="Componentes reutilizáveis (TRC-14.3) consumidos pela sidebar, chat e gates. Cada bloco abaixo mostra as variantes e estados — inspecione visualmente antes de mergear."
+        >
+          <div className="flex flex-col gap-8">
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-[0.04em] text-ink-tertiary">
+                BrandButton
+              </h3>
+              <p className="mt-1 text-xs text-ink-tertiary">
+                Quatro variantes (primary, secondary, ghost, success) e dois
+                tamanhos (default, sm). Estado disabled via prop.
+              </p>
+              <div className="mt-3 flex flex-wrap items-center gap-3 rounded-brand-lg border border-line bg-surface p-4">
+                <BrandButton>Primária</BrandButton>
+                <BrandButton variant="secondary">Secundária</BrandButton>
+                <BrandButton variant="ghost">Fantasma</BrandButton>
+                <BrandButton variant="success">Sucesso</BrandButton>
+                <BrandButton size="sm">Pequena</BrandButton>
+                <BrandButton size="sm" variant="secondary">
+                  Pequena secundária
+                </BrandButton>
+                <BrandButton disabled>Desabilitada</BrandButton>
+              </div>
+            </div>
+
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-[0.04em] text-ink-tertiary">
+                Chip
+              </h3>
+              <p className="mt-1 text-xs text-ink-tertiary">
+                Rótulos compactos com fundo tingido pela variante. Útil em
+                filtros, status e categorias.
+              </p>
+              <div className="mt-3 flex flex-wrap items-center gap-2 rounded-brand-lg border border-line bg-surface p-4">
+                <Chip>Neutro</Chip>
+                <Chip variant="primary">Primário</Chip>
+                <Chip variant="success">Sucesso</Chip>
+                <Chip variant="warning">Alerta</Chip>
+                <Chip variant="error">Erro</Chip>
+              </div>
+            </div>
+
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-[0.04em] text-ink-tertiary">
+                Dot
+              </h3>
+              <p className="mt-1 text-xs text-ink-tertiary">
+                Pontinho 6×6px para indicador de status. Use aria-label quando o
+                estado não estiver comunicado textualmente ao lado.
+              </p>
+              <div className="mt-3 flex flex-wrap items-center gap-6 rounded-brand-lg border border-line bg-surface p-4 text-xs text-ink-secondary">
+                <span className="inline-flex items-center gap-2">
+                  <Dot /> muted
+                </span>
+                <span className="inline-flex items-center gap-2">
+                  <Dot variant="primary" /> primary
+                </span>
+                <span className="inline-flex items-center gap-2">
+                  <Dot variant="success" /> success
+                </span>
+                <span className="inline-flex items-center gap-2">
+                  <Dot variant="warning" /> warning
+                </span>
+                <span className="inline-flex items-center gap-2">
+                  <Dot variant="error" /> error
+                </span>
+              </div>
+            </div>
+
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-[0.04em] text-ink-tertiary">
+                ProgressBar
+              </h3>
+              <p className="mt-1 text-xs text-ink-tertiary">
+                Track 4px com fill que transiciona a largura em 400ms. Variant
+                success quando o valor chega a 100.
+              </p>
+              <div className="mt-3 flex flex-col gap-4 rounded-brand-lg border border-line bg-surface p-4">
+                <div>
+                  <div className="mb-1 text-[11px] uppercase tracking-[0.04em] text-ink-tertiary">
+                    Coleta inicial — 25%
+                  </div>
+                  <ProgressBar value={25} aria-label="Coleta inicial" />
+                </div>
+                <div>
+                  <div className="mb-1 text-[11px] uppercase tracking-[0.04em] text-ink-tertiary">
+                    Especificação — 70%
+                  </div>
+                  <ProgressBar value={70} aria-label="Especificação" />
+                </div>
+                <div>
+                  <div className="mb-1 text-[11px] uppercase tracking-[0.04em] text-ink-tertiary">
+                    Pronto — 100%
+                  </div>
+                  <ProgressBar
+                    value={100}
+                    variant="success"
+                    aria-label="Pronto para publicar"
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-[0.04em] text-ink-tertiary">
+                TypingDots
+              </h3>
+              <p className="mt-1 text-xs text-ink-tertiary">
+                Três pontinhos com bounce staggered. Usado no chat enquanto o
+                agente está pensando.
+              </p>
+              <div className="mt-3 flex items-center gap-3 rounded-brand-lg border border-line bg-surface p-4 text-sm text-ink-secondary">
+                <TypingDots aria-label="True Coding está digitando" />
+                <span>True Coding está digitando…</span>
+              </div>
+            </div>
+
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-[0.04em] text-ink-tertiary">
+                Callout
+              </h3>
+              <p className="mt-1 text-xs text-ink-tertiary">
+                Bloco destacado para mensagens informativas. Variantes info,
+                warning, success e error. Suporta título e ícone opcionais.
+              </p>
+              <div className="mt-3 flex flex-col gap-3">
+                <Callout title="Tudo certo por aqui" variant="info">
+                  Sua coleta inicial foi salva como rascunho. Você pode voltar
+                  quando quiser.
+                </Callout>
+                <Callout title="Verifique antes de avançar" variant="warning">
+                  Alguns campos obrigatórios ainda precisam ser preenchidos.
+                </Callout>
+                <Callout title="Especificação aprovada" variant="success">
+                  A versão v1 foi congelada. Agora você pode entrar no modo de
+                  gestão.
+                </Callout>
+                <Callout title="Falha na publicação" variant="error">
+                  Não conseguimos publicar seu app. Tente novamente em alguns
+                  minutos.
+                </Callout>
+              </div>
+            </div>
+          </div>
+        </Section>
 
         <Section
           id="cores"
@@ -269,8 +426,8 @@ export default function DesignSystemPage() {
         </Section>
 
         <footer className="pt-2 text-center text-xs text-ink-quaternary">
-          TRC-14.1 · Tokens alinhados ao mockup oficial em{' '}
-          <code>/Spec/Jornada Coleta inicial/prototipo.html</code>
+          TRC-14.1 · TRC-14.3 — Tokens e primitivas alinhados ao mockup oficial
+          em <code>/Spec/Jornada Coleta inicial/prototipo.html</code>
         </footer>
       </div>
     </div>

--- a/src/components/ui/brand-button.test.tsx
+++ b/src/components/ui/brand-button.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { BrandButton } from './brand-button'
+
+describe('BrandButton', () => {
+  it('renderiza com variant primary e size default por padrão', () => {
+    render(<BrandButton>Enviar</BrandButton>)
+    const button = screen.getByRole('button', { name: 'Enviar' })
+    expect(button).toBeInTheDocument()
+    expect(button).toHaveClass('bg-brand-primary', 'h-9')
+    expect(button).toHaveAttribute('type', 'button')
+  })
+
+  it('aplica classes da variant secondary', () => {
+    render(<BrandButton variant="secondary">Cancelar</BrandButton>)
+    const button = screen.getByRole('button', { name: 'Cancelar' })
+    expect(button).toHaveClass('bg-surface', 'border', 'border-line', 'text-ink')
+  })
+
+  it('aplica classes da variant success', () => {
+    render(<BrandButton variant="success">Confirmar</BrandButton>)
+    expect(screen.getByRole('button')).toHaveClass(
+      'bg-feedback-success',
+      'text-white',
+    )
+  })
+
+  it('aplica classes do size sm', () => {
+    render(
+      <BrandButton size="sm" variant="ghost">
+        Ação
+      </BrandButton>,
+    )
+    expect(screen.getByRole('button')).toHaveClass('h-[30px]', 'px-2.5', 'text-xs')
+  })
+
+  it('renderiza o ícone marcando-o como decorativo', () => {
+    render(
+      <BrandButton icon={<svg data-testid="icon" />}>Avançar</BrandButton>,
+    )
+    const iconWrapper = screen.getByTestId('icon').parentElement
+    expect(iconWrapper).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('dispara onClick e respeita disabled', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+
+    const { rerender } = render(
+      <BrandButton onClick={onClick}>Clique</BrandButton>,
+    )
+    await user.click(screen.getByRole('button'))
+    expect(onClick).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <BrandButton disabled onClick={onClick}>
+        Clique
+      </BrandButton>,
+    )
+    const disabledBtn = screen.getByRole('button')
+    expect(disabledBtn).toBeDisabled()
+    expect(disabledBtn).toHaveClass('disabled:opacity-50')
+    await user.click(disabledBtn)
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('propaga aria-label e className', () => {
+    render(
+      <BrandButton aria-label="Enviar formulário" className="mt-2">
+        Enviar
+      </BrandButton>,
+    )
+    const button = screen.getByRole('button', { name: 'Enviar formulário' })
+    expect(button).toHaveClass('mt-2')
+  })
+
+  it('encaminha ref para o elemento button', () => {
+    const ref = { current: null as HTMLButtonElement | null }
+    render(<BrandButton ref={ref}>Enviar</BrandButton>)
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement)
+  })
+})

--- a/src/components/ui/brand-button.tsx
+++ b/src/components/ui/brand-button.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+/**
+ * TRC-14.3 — Primitiva Button do design system True Coding.
+ *
+ * Espelha 1:1 as classes `.btn`, `.btn-{primary|secondary|ghost|success}` e
+ * `.btn-sm` do mockup `Spec/Jornada Coleta inicial/prototipo.html` (linhas
+ * 66–83). Convive com o `Button` shadcn (src/components/ui/button.tsx), que
+ * segue em uso por componentes legados. A migração é tema de PR próprio.
+ */
+
+type BrandButtonVariant = 'primary' | 'secondary' | 'ghost' | 'success'
+type BrandButtonSize = 'default' | 'sm'
+
+export type BrandButtonProps = {
+  variant?: BrandButtonVariant
+  size?: BrandButtonSize
+  icon?: React.ReactNode
+  children: React.ReactNode
+  className?: string
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
+  disabled?: boolean
+  type?: 'button' | 'submit' | 'reset'
+  'aria-label'?: string
+}
+
+// Maps estáticos — evitam interpolação `bg-${variant}` que o JIT do Tailwind
+// não consegue descobrir sem safelist.
+const VARIANT_CLASSES: Record<BrandButtonVariant, string> = {
+  primary: 'bg-brand-primary text-white hover:bg-brand-primary-hover',
+  secondary:
+    'bg-surface border border-line text-ink hover:bg-surface-hover hover:border-line-strong',
+  ghost: 'text-ink-secondary hover:bg-surface-muted hover:text-ink',
+  success: 'bg-feedback-success text-white hover:bg-feedback-success-hover',
+}
+
+const SIZE_CLASSES: Record<BrandButtonSize, string> = {
+  default: 'h-9 px-3.5 text-[13px]',
+  sm: 'h-[30px] px-2.5 text-xs',
+}
+
+const BASE_CLASSES =
+  'inline-flex items-center gap-1.5 rounded-brand-md font-medium transition-colors focus-visible:outline-2 focus-visible:outline-brand-primary focus-visible:outline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none'
+
+export const BrandButton = React.forwardRef<HTMLButtonElement, BrandButtonProps>(
+  function BrandButton(
+    {
+      variant = 'primary',
+      size = 'default',
+      icon,
+      children,
+      className,
+      type = 'button',
+      ...rest
+    },
+    ref,
+  ) {
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={cn(
+          BASE_CLASSES,
+          SIZE_CLASSES[size],
+          VARIANT_CLASSES[variant],
+          className,
+        )}
+        {...rest}
+      >
+        {icon ? (
+          <span className="inline-flex shrink-0 items-center" aria-hidden>
+            {icon}
+          </span>
+        ) : null}
+        {children}
+      </button>
+    )
+  },
+)

--- a/src/components/ui/callout.test.tsx
+++ b/src/components/ui/callout.test.tsx
@@ -22,15 +22,15 @@ describe('Callout', () => {
     }> = [
       {
         variant: 'warning',
-        expected: ['border-feedback-warning-light', 'bg-feedback-warning-light'],
+        expected: ['border-feedback-warning', 'bg-feedback-warning-light'],
       },
       {
         variant: 'success',
-        expected: ['border-feedback-success-light', 'bg-feedback-success-light'],
+        expected: ['border-feedback-success', 'bg-feedback-success-light'],
       },
       {
         variant: 'error',
-        expected: ['border-feedback-error-light', 'bg-feedback-error-light'],
+        expected: ['border-feedback-error', 'bg-feedback-error-light'],
       },
     ]
 

--- a/src/components/ui/callout.test.tsx
+++ b/src/components/ui/callout.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { Callout } from './callout'
+
+describe('Callout', () => {
+  it('renderiza com role note e variant info por padrão', () => {
+    render(<Callout>Sua coleta foi salva.</Callout>)
+    const note = screen.getByRole('note')
+    expect(note).toHaveTextContent('Sua coleta foi salva.')
+    expect(note).toHaveClass(
+      'border-brand-primary-light',
+      'bg-brand-primary-lighter',
+      'text-brand-primary',
+    )
+  })
+
+  it('aplica classes para cada variant', () => {
+    const cases: Array<{
+      variant: 'warning' | 'success' | 'error'
+      expected: string[]
+    }> = [
+      {
+        variant: 'warning',
+        expected: ['border-feedback-warning-light', 'bg-feedback-warning-light'],
+      },
+      {
+        variant: 'success',
+        expected: ['border-feedback-success-light', 'bg-feedback-success-light'],
+      },
+      {
+        variant: 'error',
+        expected: ['border-feedback-error-light', 'bg-feedback-error-light'],
+      },
+    ]
+
+    for (const { variant, expected } of cases) {
+      const { unmount } = render(<Callout variant={variant}>Mensagem</Callout>)
+      const note = screen.getByRole('note')
+      expected.forEach((klass) => expect(note).toHaveClass(klass))
+      unmount()
+    }
+  })
+
+  it('renderiza título em negrito e marca ícone como decorativo', () => {
+    render(
+      <Callout
+        title="Atenção"
+        icon={<svg data-testid="icon" />}
+        variant="warning"
+      >
+        Verifique os campos obrigatórios.
+      </Callout>,
+    )
+    expect(screen.getByText('Atenção')).toHaveClass('font-semibold')
+    expect(
+      screen.getByText('Verifique os campos obrigatórios.'),
+    ).toBeInTheDocument()
+    const iconWrapper = screen.getByTestId('icon').parentElement
+    expect(iconWrapper).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('propaga className adicional', () => {
+    render(<Callout className="mt-4">Conteúdo</Callout>)
+    expect(screen.getByRole('note')).toHaveClass('mt-4')
+  })
+})

--- a/src/components/ui/callout.tsx
+++ b/src/components/ui/callout.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+/**
+ * TRC-14.3 — Primitiva Callout do design system True Coding.
+ *
+ * O mockup `Spec/Jornada Coleta inicial/prototipo.html` não define uma classe
+ * `.callout`, mas os JSX do canvas/chat (`src/canvas.jsx`) usam o padrão:
+ * bloco com fundo + borda tingidos pela cor do feedback (info, warning,
+ * success, error) e um slot de ícone à esquerda com o texto à direita.
+ *
+ * Variante `info` usa a paleta `brand-primary-*` (o mockup trata mensagens
+ * neutras/informacionais com o azul da marca).
+ */
+
+type CalloutVariant = 'info' | 'warning' | 'success' | 'error'
+
+export type CalloutProps = {
+  variant?: CalloutVariant
+  icon?: React.ReactNode
+  title?: string
+  children: React.ReactNode
+  className?: string
+}
+
+const VARIANT_CLASSES: Record<CalloutVariant, string> = {
+  info: 'border-brand-primary-light bg-brand-primary-lighter text-brand-primary',
+  warning:
+    'border-feedback-warning-light bg-feedback-warning-light text-feedback-warning-hover',
+  success:
+    'border-feedback-success-light bg-feedback-success-light text-feedback-success-hover',
+  error: 'border-feedback-error-light bg-feedback-error-light text-feedback-error',
+}
+
+const BASE_CLASSES = 'flex gap-3 rounded-brand-lg border p-3 text-sm'
+
+export function Callout({
+  variant = 'info',
+  icon,
+  title,
+  children,
+  className,
+}: CalloutProps) {
+  return (
+    <div
+      role="note"
+      className={cn(BASE_CLASSES, VARIANT_CLASSES[variant], className)}
+    >
+      {icon ? (
+        <div className="flex-shrink-0" aria-hidden>
+          {icon}
+        </div>
+      ) : null}
+      <div className="flex-1">
+        {title ? <div className="font-semibold">{title}</div> : null}
+        <div className={cn(title ? 'mt-0.5' : undefined)}>{children}</div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui/callout.tsx
+++ b/src/components/ui/callout.tsx
@@ -24,13 +24,15 @@ export type CalloutProps = {
   className?: string
 }
 
+// border usa a cor-base (mais saturada) e bg usa a variante -light/-lighter
+// para que a borda fique visivel sobre o fundo (pattern alinhado ao mockup).
 const VARIANT_CLASSES: Record<CalloutVariant, string> = {
   info: 'border-brand-primary-light bg-brand-primary-lighter text-brand-primary',
   warning:
-    'border-feedback-warning-light bg-feedback-warning-light text-feedback-warning-hover',
+    'border-feedback-warning bg-feedback-warning-light text-feedback-warning-hover',
   success:
-    'border-feedback-success-light bg-feedback-success-light text-feedback-success-hover',
-  error: 'border-feedback-error-light bg-feedback-error-light text-feedback-error',
+    'border-feedback-success bg-feedback-success-light text-feedback-success-hover',
+  error: 'border-feedback-error bg-feedback-error-light text-feedback-error',
 }
 
 const BASE_CLASSES = 'flex gap-3 rounded-brand-lg border p-3 text-sm'

--- a/src/components/ui/chip.test.tsx
+++ b/src/components/ui/chip.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { Chip } from './chip'
+
+describe('Chip', () => {
+  it('renderiza com variant neutral por padrão', () => {
+    render(<Chip>Rascunho</Chip>)
+    const chip = screen.getByText('Rascunho')
+    expect(chip).toHaveClass(
+      'bg-surface-muted',
+      'text-ink-secondary',
+      'rounded-full',
+    )
+  })
+
+  it('aplica classes corretas para cada variant', () => {
+    const { rerender } = render(<Chip variant="primary">Primária</Chip>)
+    expect(screen.getByText('Primária')).toHaveClass(
+      'bg-brand-primary-light',
+      'text-brand-primary',
+    )
+
+    rerender(<Chip variant="success">Sucesso</Chip>)
+    expect(screen.getByText('Sucesso')).toHaveClass(
+      'bg-feedback-success-light',
+      'text-feedback-success-hover',
+    )
+
+    rerender(<Chip variant="warning">Alerta</Chip>)
+    expect(screen.getByText('Alerta')).toHaveClass(
+      'bg-feedback-warning-light',
+      'text-feedback-warning-hover',
+    )
+
+    rerender(<Chip variant="error">Erro</Chip>)
+    expect(screen.getByText('Erro')).toHaveClass(
+      'bg-feedback-error-light',
+      'text-[#b91c1c]',
+    )
+  })
+
+  it('propaga className adicional', () => {
+    render(<Chip className="ml-2">Rótulo</Chip>)
+    expect(screen.getByText('Rótulo')).toHaveClass('ml-2')
+  })
+})

--- a/src/components/ui/chip.tsx
+++ b/src/components/ui/chip.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+/**
+ * TRC-14.3 — Primitiva Chip do design system True Coding.
+ *
+ * Espelha `.chip` + variantes do mockup `Spec/Jornada Coleta inicial/prototipo.html`
+ * (linhas 85–94). A variante `error` usa `#b91c1c` para o texto (não há token
+ * dedicado; o mockup aplica o hex literal).
+ */
+
+type ChipVariant = 'neutral' | 'primary' | 'success' | 'warning' | 'error'
+
+export type ChipProps = {
+  variant?: ChipVariant
+  children: React.ReactNode
+  className?: string
+}
+
+const VARIANT_CLASSES: Record<ChipVariant, string> = {
+  neutral: 'bg-surface-muted text-ink-secondary',
+  primary: 'bg-brand-primary-light text-brand-primary',
+  success: 'bg-feedback-success-light text-feedback-success-hover',
+  warning: 'bg-feedback-warning-light text-feedback-warning-hover',
+  error: 'bg-feedback-error-light text-[#b91c1c]',
+}
+
+const BASE_CLASSES =
+  'inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[11px] font-medium'
+
+export function Chip({ variant = 'neutral', children, className }: ChipProps) {
+  return (
+    <span className={cn(BASE_CLASSES, VARIANT_CLASSES[variant], className)}>
+      {children}
+    </span>
+  )
+}

--- a/src/components/ui/dot.test.tsx
+++ b/src/components/ui/dot.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+
+import { Dot } from './dot'
+
+describe('Dot', () => {
+  it('renderiza com variant muted por padrão e aria-hidden', () => {
+    const { container } = render(<Dot />)
+    const dot = container.firstElementChild
+    expect(dot).not.toBeNull()
+    expect(dot).toHaveClass('bg-ink-quaternary', 'h-1.5', 'w-1.5', 'rounded-full')
+    expect(dot).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('aplica classes corretas para cada variant', () => {
+    const cases: Array<{
+      variant: 'primary' | 'success' | 'warning' | 'error'
+      expected: string
+    }> = [
+      { variant: 'primary', expected: 'bg-brand-primary' },
+      { variant: 'success', expected: 'bg-feedback-success' },
+      { variant: 'warning', expected: 'bg-feedback-warning' },
+      { variant: 'error', expected: 'bg-feedback-error' },
+    ]
+
+    for (const { variant, expected } of cases) {
+      const { container } = render(<Dot variant={variant} />)
+      expect(container.firstElementChild).toHaveClass(expected)
+    }
+  })
+
+  it('expõe role img e aria-label quando rotulado', () => {
+    const { container } = render(
+      <Dot variant="success" aria-label="Status conectado" />,
+    )
+    const dot = container.firstElementChild
+    expect(dot).toHaveAttribute('role', 'img')
+    expect(dot).toHaveAttribute('aria-label', 'Status conectado')
+    expect(dot).not.toHaveAttribute('aria-hidden')
+  })
+
+  it('propaga className adicional', () => {
+    const { container } = render(<Dot className="mr-1" />)
+    expect(container.firstElementChild).toHaveClass('mr-1')
+  })
+})

--- a/src/components/ui/dot.tsx
+++ b/src/components/ui/dot.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+/**
+ * TRC-14.3 — Primitiva Dot do design system True Coding.
+ *
+ * Espelha `.dot` (6×6px, border-radius 9999) + variantes do mockup
+ * `Spec/Jornada Coleta inicial/prototipo.html` (linhas 96–100).
+ */
+
+type DotVariant = 'muted' | 'primary' | 'success' | 'warning' | 'error'
+
+export type DotProps = {
+  variant?: DotVariant
+  className?: string
+  'aria-label'?: string
+}
+
+const VARIANT_CLASSES: Record<DotVariant, string> = {
+  muted: 'bg-ink-quaternary',
+  primary: 'bg-brand-primary',
+  success: 'bg-feedback-success',
+  warning: 'bg-feedback-warning',
+  error: 'bg-feedback-error',
+}
+
+const BASE_CLASSES = 'inline-block h-1.5 w-1.5 rounded-full'
+
+export function Dot({
+  variant = 'muted',
+  className,
+  'aria-label': ariaLabel,
+}: DotProps) {
+  return (
+    <span
+      className={cn(BASE_CLASSES, VARIANT_CLASSES[variant], className)}
+      aria-label={ariaLabel}
+      aria-hidden={ariaLabel ? undefined : true}
+      role={ariaLabel ? 'img' : undefined}
+    />
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,20 @@
+/**
+ * TRC-14.3 — Barrel das primitivas do design system True Coding.
+ *
+ * Re-exporta apenas as primitivas novas (Brand*) criadas em TRC-14.3. Os
+ * componentes shadcn (Button, toast) continuam sendo importados direto dos
+ * seus módulos para evitar alterar imports existentes no repo.
+ */
+
+export { BrandButton } from './brand-button'
+export type { BrandButtonProps } from './brand-button'
+export { Chip } from './chip'
+export type { ChipProps } from './chip'
+export { Dot } from './dot'
+export type { DotProps } from './dot'
+export { ProgressBar } from './progress-bar'
+export type { ProgressBarProps } from './progress-bar'
+export { TypingDots } from './typing-dots'
+export type { TypingDotsProps } from './typing-dots'
+export { Callout } from './callout'
+export type { CalloutProps } from './callout'

--- a/src/components/ui/progress-bar.test.tsx
+++ b/src/components/ui/progress-bar.test.tsx
@@ -40,6 +40,22 @@ describe('ProgressBar', () => {
     expect(fill).toHaveStyle({ width: '0%' })
   })
 
+  it('trata NaN como 0% (defensivo contra valores invalidos)', () => {
+    const { container } = render(<ProgressBar value={Number.NaN} />)
+    const bar = screen.getByRole('progressbar')
+    const fill = container.querySelector('[role="progressbar"] > div')
+    expect(bar).toHaveAttribute('aria-valuenow', '0')
+    expect(fill).toHaveStyle({ width: '0%' })
+  })
+
+  it('aplica aria-label default "Progresso" quando omitido', () => {
+    render(<ProgressBar value={50} />)
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-label',
+      'Progresso',
+    )
+  })
+
   it('propaga className adicional ao track', () => {
     render(<ProgressBar value={20} className="mt-4" />)
     expect(screen.getByRole('progressbar')).toHaveClass('mt-4')

--- a/src/components/ui/progress-bar.test.tsx
+++ b/src/components/ui/progress-bar.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { ProgressBar } from './progress-bar'
+
+describe('ProgressBar', () => {
+  it('renderiza com role progressbar e valores ARIA', () => {
+    render(<ProgressBar value={40} aria-label="Progresso da coleta" />)
+    const bar = screen.getByRole('progressbar', { name: 'Progresso da coleta' })
+    expect(bar).toHaveAttribute('aria-valuemin', '0')
+    expect(bar).toHaveAttribute('aria-valuemax', '100')
+    expect(bar).toHaveAttribute('aria-valuenow', '40')
+  })
+
+  it('aplica largura proporcional ao value no fill', () => {
+    const { container } = render(<ProgressBar value={65} />)
+    const fill = container.querySelector('[role="progressbar"] > div')
+    expect(fill).not.toBeNull()
+    expect(fill).toHaveStyle({ width: '65%' })
+    expect(fill).toHaveClass('bg-brand-primary')
+  })
+
+  it('aplica variant success quando solicitada', () => {
+    const { container } = render(<ProgressBar value={100} variant="success" />)
+    const fill = container.querySelector('[role="progressbar"] > div')
+    expect(fill).toHaveClass('bg-feedback-success')
+  })
+
+  it('clampa valores fora do intervalo [0, 100]', () => {
+    const { container, rerender } = render(<ProgressBar value={150} />)
+    let bar = screen.getByRole('progressbar')
+    let fill = container.querySelector('[role="progressbar"] > div')
+    expect(bar).toHaveAttribute('aria-valuenow', '100')
+    expect(fill).toHaveStyle({ width: '100%' })
+
+    rerender(<ProgressBar value={-25} />)
+    bar = screen.getByRole('progressbar')
+    fill = container.querySelector('[role="progressbar"] > div')
+    expect(bar).toHaveAttribute('aria-valuenow', '0')
+    expect(fill).toHaveStyle({ width: '0%' })
+  })
+
+  it('propaga className adicional ao track', () => {
+    render(<ProgressBar value={20} className="mt-4" />)
+    expect(screen.getByRole('progressbar')).toHaveClass('mt-4')
+  })
+})

--- a/src/components/ui/progress-bar.tsx
+++ b/src/components/ui/progress-bar.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+/**
+ * TRC-14.3 — Primitiva ProgressBar do design system True Coding.
+ *
+ * Espelha `.progress-track` + `.progress-fill` do mockup
+ * `Spec/Jornada Coleta inicial/prototipo.html` (linhas 127–128): track cinza
+ * (bg-line, 4px de altura) com fill azul que transiciona a largura em 400ms.
+ */
+
+type ProgressBarVariant = 'primary' | 'success'
+
+export type ProgressBarProps = {
+  value: number
+  variant?: ProgressBarVariant
+  className?: string
+  'aria-label'?: string
+}
+
+const FILL_VARIANT_CLASSES: Record<ProgressBarVariant, string> = {
+  primary: 'bg-brand-primary',
+  success: 'bg-feedback-success',
+}
+
+function clampPercent(value: number): number {
+  if (Number.isNaN(value)) return 0
+  if (value < 0) return 0
+  if (value > 100) return 100
+  return value
+}
+
+export function ProgressBar({
+  value,
+  variant = 'primary',
+  className,
+  'aria-label': ariaLabel,
+}: ProgressBarProps) {
+  const percent = clampPercent(value)
+
+  return (
+    <div
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={percent}
+      aria-label={ariaLabel}
+      className={cn(
+        'h-1 w-full overflow-hidden rounded-full bg-line',
+        className,
+      )}
+    >
+      <div
+        className={cn(
+          'h-full rounded-full transition-[width] duration-[400ms] ease-out',
+          FILL_VARIANT_CLASSES[variant],
+        )}
+        style={{ width: `${percent}%` }}
+      />
+    </div>
+  )
+}

--- a/src/components/ui/progress-bar.tsx
+++ b/src/components/ui/progress-bar.tsx
@@ -45,7 +45,7 @@ export function ProgressBar({
       aria-valuemin={0}
       aria-valuemax={100}
       aria-valuenow={percent}
-      aria-label={ariaLabel}
+      aria-label={ariaLabel ?? 'Progresso'}
       className={cn(
         'h-1 w-full overflow-hidden rounded-full bg-line',
         className,

--- a/src/components/ui/typing-dots.test.tsx
+++ b/src/components/ui/typing-dots.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { TypingDots } from './typing-dots'
+
+describe('TypingDots', () => {
+  it('renderiza com role status e aria-label padrão "Carregando"', () => {
+    render(<TypingDots />)
+    const status = screen.getByRole('status', { name: 'Carregando' })
+    expect(status).toBeInTheDocument()
+  })
+
+  it('permite customizar aria-label', () => {
+    render(<TypingDots aria-label="True Coding está digitando" />)
+    expect(
+      screen.getByRole('status', { name: 'True Coding está digitando' }),
+    ).toBeInTheDocument()
+  })
+
+  it('renderiza 3 pontos com animação staggered', () => {
+    const { container } = render(<TypingDots />)
+    const dots = container.querySelectorAll('span > span')
+    expect(dots).toHaveLength(3)
+    dots.forEach((dot) => {
+      expect(dot).toHaveClass('animate-typing-bounce')
+    })
+    expect(dots[1]).toHaveClass('[animation-delay:0.2s]')
+    expect(dots[2]).toHaveClass('[animation-delay:0.4s]')
+  })
+
+  it('propaga className ao container', () => {
+    render(<TypingDots className="ml-1" />)
+    expect(screen.getByRole('status')).toHaveClass('ml-1')
+  })
+})

--- a/src/components/ui/typing-dots.tsx
+++ b/src/components/ui/typing-dots.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+/**
+ * TRC-14.3 — Primitiva TypingDots do design system True Coding.
+ *
+ * Espelha `.typing-dots` do mockup `Spec/Jornada Coleta inicial/prototipo.html`
+ * (linhas 131–138): três bolinhas 5×5px com animação `bounce` staggered em
+ * 200ms. Usa a animação `typing-bounce` registrada no Tailwind (TRC-14.1), que
+ * é keyframe própria para não colidir com a `animate-bounce` built-in.
+ */
+
+export type TypingDotsProps = {
+  'aria-label'?: string
+  className?: string
+}
+
+const DOT_BASE =
+  'h-[5px] w-[5px] rounded-full bg-ink-tertiary animate-typing-bounce'
+
+export function TypingDots({
+  'aria-label': ariaLabel = 'Carregando',
+  className,
+}: TypingDotsProps) {
+  return (
+    <span
+      role="status"
+      aria-label={ariaLabel}
+      className={cn('inline-flex items-center gap-[3px]', className)}
+    >
+      <span className={DOT_BASE} />
+      <span className={cn(DOT_BASE, '[animation-delay:0.2s]')} />
+      <span className={cn(DOT_BASE, '[animation-delay:0.4s]')} />
+    </span>
+  )
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,6 +12,8 @@ const config: Config = {
   // namespaces do design system; nao afeta classes do shadcn/ui.
   safelist: [
     { pattern: /^(bg|text)-(brand|feedback|surface|ink|line)(-[a-z-]+)?$/ },
+    { pattern: /^rounded-brand-(sm|md|lg|xl)$/ },
+    { pattern: /^shadow-brand-(sm|md|lg)$/ },
     {
       pattern:
         /^animate-(fade-in|slide-up|slide-in-right|pulse-soft|typing-bounce)$/,


### PR DESCRIPTION
## Summary

Adiciona 6 primitivas do design system em `src/components/ui/`, alinhadas 1:1 ao mockup `Spec/Jornada Coleta inicial/prototipo.html`. Consumidas por TRC-14.4 (Sidebar), TRC-14.8 (viewport gate) e todos os épicos de jornada (TRC-15 a TRC-19).

4ª sub-task do épico TRC-14 Fundação.

Notion: [TRC-14.3](https://www.notion.so/34b0d9578db381ae90c4efb117f97247) · [TRC-14](https://www.notion.so/34b0d9578db3813e860ecacb4a83055e)

## Primitivas

| Componente | Variants | A11y |
|---|---|---|
| `BrandButton` | primary / secondary / ghost / success + sizes default/sm + icon slot | forwardRef + aria-label |
| `Chip` | neutral / primary / success / warning / error | — |
| `Dot` | muted / primary / success / warning / error | role=img só se aria-label |
| `ProgressBar` | primary / success + clamp [0,100] | role=progressbar + valuenow/min/max |
| `TypingDots` | — (decorativo animado) | role=status |
| `Callout` | info / warning / success / error + icon + title | role=note |

## Shadcn coexistence

Primitivas criadas em arquivos novos (`brand-button.tsx`, etc.); shadcn `Button` **intacto**. Barrel `index.ts` exporta só os `Brand*`. Migração de consumidores fica pra refactor futuro, fora deste escopo.

## Tamanho

~826 linhas:
- 343 linhas código das 6 primitivas
- 326 linhas testes (28 novos)
- 157 linhas showcase em `/design-system`

Passa do limite <400 mas a natureza atômica (primitivas + testes + visual verification) justifica manter junto.

## Test plan

- [x] `npm run lint` limpo
- [x] `npm run build` passa
- [x] `npm test` — 552/552 (28 novos)
- [ ] Abrir `/design-system` em dev, comparar primitivas com mockup
- [ ] Verificar que shadcn Button continua funcionando em `DashboardHeader`/`ProjectSidebar`

🤖 Generated with [Claude Code](https://claude.com/claude-code)