### PR TITLE
feat(migrations): script plans JSON → PlanBlock (TRC-14.6)

### DIFF
--- a/docs/migrations/2026-04-plans-to-blocks.md
+++ b/docs/migrations/2026-04-plans-to-blocks.md
@@ -36,9 +36,23 @@ Para cada `Project` candidato:
 
 ### Campos legados que não têm bloco dedicado
 
-- `businessPlan.niceToHaveFeatures` e `businessPlan.successMetrics` são anexados respectivamente aos blocos `features` e `diferenciais` para não perder informação.
-- `technicalPlan.apiEndpoints` e `technicalPlan.realtime` são anexados ao bloco `integracoes`.
-- `uxPlan.informationArchitecture` é anexado ao bloco `telas`.
+Anexados a blocos existentes (sem perda):
+
+- `businessPlan.niceToHaveFeatures` e `businessPlan.successMetrics` → blocos `features` e `diferenciais` respectivamente.
+- `technicalPlan.apiEndpoints` e `technicalPlan.realtime` → bloco `integracoes`.
+- `uxPlan.informationArchitecture` → bloco `telas`.
+
+### Campos legados NÃO migrados (design deliberado)
+
+Os seguintes campos do shape legacy são **descartados** na migração — ainda ficam preservados no `legacyPlans` cru, mas não aparecem em nenhum `PlanBlock`:
+
+- `technicalPlan.security` — vai virar campo de Risk Log na Fase Gestão (POLICY-003).
+- `technicalPlan.performance` — métricas, melhor modeladas como assumptions do Product Context (POLICY-010).
+- `technicalPlan.testing` — estratégia de testes não é conteúdo de plano; vira playbook.
+- `technicalPlan.deployment` — deploy é responsabilidade de CodeGen congelado (ADR-008).
+- `uxPlan.pages` e `uxPlan.components` — sobrepõem `uxPlan.wireframes` (bloco `telas`).
+
+**Se precisar**: `Project.legacyPlans` mantém o JSON completo por 30 dias — é possível extrair esses campos manualmente pra outro destino antes do drop.
 
 ## Como rodar
 

--- a/docs/migrations/2026-04-plans-to-blocks.md
+++ b/docs/migrations/2026-04-plans-to-blocks.md
@@ -1,0 +1,135 @@
+# Migração: JSON blobs de planos → PlanBlock granular
+
+**Ticket:** TRC-14.6
+**Data:** 2026-04
+**Script:** `prisma/migrations/scripts/migrate-plans-to-blocks.ts`
+**Epic:** TRC-14 — Fundação da plataforma
+
+## O que a migration faz
+
+Converte os campos legados `Project.businessPlan`, `Project.technicalPlan` e `Project.uxPlan` (JSON monolíticos) em blocos canônicos na tabela `PlanBlock`, habilitando o canvas granular consumido por TRC-18.
+
+Para cada `Project` candidato:
+
+1. Lê os três campos JSON legados.
+2. Parseia cada plano para um mapa `blockId → body (markdown)` conforme o mapeamento canônico:
+   - **Negócio (6 blocos):** `visao`, `problema`, `publico`, `features`, `diferenciais`, `monetizacao`
+   - **UX (4 blocos):** `personas`, `jornadas`, `telas`, `tokens`
+   - **Técnico (4 blocos):** `stack`, `arquitetura`, `dados`, `integracoes`
+3. Cria os `PlanBlock` correspondentes com `status = APPROVED` e `approvedAt = Project.updatedAt`. Planos antigos são considerados já aprovados porque o produto só permite avançar de fase após aprovação explícita.
+4. Preserva o JSON original em `Project.legacyPlans` com um `migratedAt`:
+   ```json
+   {
+     "migratedAt": "2026-04-22T...",
+     "businessPlan": { ... JSON original ... },
+     "technicalPlan": { ... },
+     "uxPlan": { ... }
+   }
+   ```
+
+### Propriedades
+
+- **Idempotente:** projetos com `legacyPlans` já preenchido são pulados.
+- **Transacional:** cada projeto migra num único `$transaction` — ou tudo, ou nada.
+- **Seguro com dados malformados:** se um bloco específico não pode ser derivado do JSON, o script usa fallback (dump cru do JSON num bloco do mesmo plano) e loga warning. Nenhum dado é perdido.
+- **Seleção:** sem filtro → todos os projetos com algum plano não-null e `legacyPlans = null`. Com `--project-id=<id>`, migra apenas o projeto indicado (útil para testar ou retomar).
+
+### Campos legados que não têm bloco dedicado
+
+- `businessPlan.niceToHaveFeatures` e `businessPlan.successMetrics` são anexados respectivamente aos blocos `features` e `diferenciais` para não perder informação.
+- `technicalPlan.apiEndpoints` e `technicalPlan.realtime` são anexados ao bloco `integracoes`.
+- `uxPlan.informationArchitecture` é anexado ao bloco `telas`.
+
+## Como rodar
+
+### Dev (local, banco de desenvolvimento)
+
+```bash
+# 1. Dry-run (não escreve nada, apenas loga o que faria)
+npm run db:migrate:plans-to-blocks -- --dry-run
+
+# 2. Migra apenas um projeto específico (útil para validar)
+npm run db:migrate:plans-to-blocks -- --project-id=cm1abc123
+
+# 3. Roda tudo
+npm run db:migrate:plans-to-blocks
+```
+
+O script usa o `DATABASE_URL` configurado em `.env.local`.
+
+### Produção
+
+1. **Snapshot do banco** antes de rodar (responsabilidade do operador).
+2. **Dry-run primeiro:** `npm run db:migrate:plans-to-blocks -- --dry-run` e validar logs.
+3. **Escolher um projeto piloto:** rodar `--project-id=<id>` e validar manualmente:
+   ```sql
+   SELECT id, "legacyPlans" IS NOT NULL AS migrated FROM projects WHERE id = '<id>';
+   SELECT plan_type, block_id, "order", status FROM plan_blocks WHERE project_id = '<id>' ORDER BY plan_type, "order";
+   ```
+4. **Rodar migração global** em janela de baixo tráfego.
+5. **Validar contagem:** número de projetos migrados deve bater com o esperado.
+6. **Smoke test na UI:** abrir um projeto migrado e confirmar que os planos renderizam (TRC-18).
+
+## Plano de rollback
+
+O JSON original está preservado em `Project.legacyPlans`. Para reverter:
+
+### Opção A — Rollback por projeto (simples)
+
+1. Deletar os blocos do projeto:
+   ```sql
+   DELETE FROM plan_blocks WHERE project_id = '<id>';
+   ```
+2. Restaurar os campos JSON originais a partir de `legacyPlans`:
+   ```sql
+   UPDATE projects SET
+     "businessPlan" = "legacyPlans"->'businessPlan',
+     "technicalPlan" = "legacyPlans"->'technicalPlan',
+     "uxPlan" = "legacyPlans"->'uxPlan',
+     "legacyPlans" = NULL
+   WHERE id = '<id>';
+   ```
+
+### Opção B — Rollback global (se um bug for detectado logo após rodar)
+
+Repetir a Opção A numa tabela inteira:
+
+```sql
+DELETE FROM plan_blocks
+WHERE project_id IN (SELECT id FROM projects WHERE "legacyPlans" IS NOT NULL);
+
+UPDATE projects SET
+  "businessPlan" = "legacyPlans"->'businessPlan',
+  "technicalPlan" = "legacyPlans"->'technicalPlan',
+  "uxPlan" = "legacyPlans"->'uxPlan',
+  "legacyPlans" = NULL
+WHERE "legacyPlans" IS NOT NULL;
+```
+
+> **Nota:** os campos legados `businessPlan/technicalPlan/uxPlan` **não são apagados** por esta migração. Continuam com o valor original no DB durante toda a janela de retenção (ver abaixo), o que torna o rollback trivial. O `legacyPlans` é um backup redundante que só é removido no PR que deleta as colunas.
+
+## Janela de retenção
+
+`Project.legacyPlans` deve permanecer no schema por **30 dias** após a migração em produção. Durante esse período:
+
+- O rollback é imediato (SQL acima).
+- Nenhum código da aplicação lê `legacyPlans`.
+
+Após 30 dias sem incidentes:
+
+1. Abrir PR separado que remove `legacyPlans`, `businessPlan`, `technicalPlan`, `uxPlan` do schema (com migration Prisma).
+2. Atualizar este documento com a data de remoção.
+
+Esta separação segue TBD: a migração de dados e a remoção das colunas são PRs independentes, permitindo rollback sem revert de código.
+
+## O que **não** está no escopo deste PR
+
+- Deletar colunas legadas `Project.businessPlan/technicalPlan/uxPlan` — ver "Janela de retenção".
+- UI consumindo `PlanBlock` — TRC-18.
+- Seed da persona Maria — TRC-14.7 (depende desta migração).
+
+## Testes
+
+- `prisma/migrations/scripts/migrate-plans-to-blocks.test.ts` — testes de integração contra o DB configurado em `DATABASE_URL`.
+- A suite skipa graciosamente se o DB não estiver acessível, seguindo o padrão de `prisma/schema.test.ts`.
+- Cobertura: 3 planos completos → 14 blocos; plano único; idempotência (2 runs); dry-run não persiste; projeto sem planos; dado malformado vai para fallback; filtro global ignora já migrados.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "true-coding",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
         "@clerk/nextjs": "^6.9.0",
@@ -41,6 +42,7 @@
         "postcss": "^8.4.0",
         "prisma": "^6.2.0",
         "tailwindcss": "^3.4.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
       }
@@ -9050,6 +9052,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
-    "db:studio": "prisma studio"
+    "db:studio": "prisma studio",
+    "db:migrate:plans-to-blocks": "tsx prisma/migrations/scripts/migrate-plans-to-blocks.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",
@@ -50,6 +51,7 @@
     "postcss": "^8.4.0",
     "prisma": "^6.2.0",
     "tailwindcss": "^3.4.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   }

--- a/prisma/migrations/scripts/migrate-plans-to-blocks.test.ts
+++ b/prisma/migrations/scripts/migrate-plans-to-blocks.test.ts
@@ -1,0 +1,386 @@
+/**
+ * TRC-14.6 — Testes de integração da migração JSON blobs → PlanBlock.
+ *
+ * Rodam contra o DATABASE_URL configurado, seguindo o padrão de
+ * prisma/schema.test.ts: se o DB não estiver acessível, a suite é skipada
+ * (evita quebrar CI sem credenciais).
+ *
+ * Cada teste isola dados num User descartável via randomUUID().
+ */
+
+// @vitest-environment node
+import { randomUUID } from 'node:crypto'
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import { PrismaClient } from '@prisma/client'
+import { migrate, type Logger } from './migrate-plans-to-blocks'
+
+const prisma = new PrismaClient({ log: ['error'] })
+
+// Probe DB — se falha, pula toda a suite.
+let dbReachable = false
+try {
+  await prisma.$connect()
+  await prisma.$queryRawUnsafe('SELECT 1')
+  dbReachable = true
+} catch {
+  dbReachable = false
+}
+
+const describeIfDb = dbReachable ? describe : describe.skip
+
+// Logger silencioso para não poluir output dos testes.
+const silentLogger: Logger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+}
+
+// Plano de negócio de exemplo — shape da interface BusinessPlan (src/types/index.ts).
+const sampleBusinessPlan = {
+  name: 'Cafeteria Bairro',
+  tagline: 'Gestão de pedidos sem complicar o balcão',
+  description: 'App para donos de cafeterias capturarem pedidos via Pix.',
+  problemStatement: 'Cafeterias perdem pedidos no rush por não responder WhatsApp a tempo.',
+  targetAudience: {
+    primary: 'Donos de cafeteria de bairro',
+    secondary: 'Atendentes do balcão',
+    painPoints: ['Rush tira o foco', 'WhatsApp manual é lento'],
+  },
+  coreFeatures: [
+    { id: 'f1', name: 'Captura por link', priority: 'must-have', complexity: 'low' },
+    { id: 'f2', name: 'Notificação Pix', priority: 'must-have', complexity: 'medium' },
+  ],
+  niceToHaveFeatures: [
+    { id: 'f3', name: 'Fidelidade', priority: 'nice-to-have', complexity: 'medium' },
+  ],
+  monetization: { model: 'subscription', description: 'R$ 49/mês por loja' },
+  competitors: [{ name: 'iFood', differentiator: 'Comissão de 25%' }],
+  successMetrics: [{ name: 'Pedidos/semana', target: '50', timeframe: 'Mês 1' }],
+}
+
+const sampleUxPlan = {
+  personas: [
+    { name: 'Maria Clara — Dona', initials: 'MC', age: 42, goals: ['Reduzir custo'] },
+  ],
+  journeys: [
+    { name: 'Primeiro pedido', persona: 'Maria Clara', steps: [{ title: 'Descoberta' }] },
+  ],
+  wireframes: [{ name: 'Dashboard', description: 'Visão geral' }],
+  informationArchitecture: { sitemap: 'Dashboard > Pedidos', navigation: [] },
+  designTokens: {
+    colors: { primary: '#2563eb', secondary: '#6366f1' },
+    spacing: [{ name: 'space-1', value: '4px' }],
+  },
+}
+
+const sampleTechnicalPlan = {
+  stack: { categories: [{ name: 'Frontend', technologies: ['Next.js 15', 'React 19'] }] },
+  architecture: {
+    pattern: 'Monolito modular',
+    organization: 'Feature-based folders',
+  },
+  database: { description: 'Postgres', prismaSchema: 'model User {...}', summary: '3 models' },
+  dataModel: { entities: [{ name: 'Order', fields: [] }] },
+  apiEndpoints: [
+    { category: 'Pedidos', endpoints: [{ method: 'POST', path: '/api/orders', description: 'Cria' }] },
+  ],
+  integrations: [{ name: 'Mercado Pago', description: 'Pix', details: 'Webhook' }],
+  realtime: { provider: 'Pusher', description: 'Pedidos ao vivo', channels: [], scalability: '100k' },
+}
+
+describeIfDb('migrate-plans-to-blocks', () => {
+  let userId: string
+  const createdUserIds: string[] = []
+
+  beforeAll(async () => {
+    await prisma.$connect()
+  })
+
+  afterAll(async () => {
+    await prisma.$disconnect()
+  })
+
+  beforeEach(async () => {
+    const unique = randomUUID().slice(0, 8)
+    const user = await prisma.user.create({
+      data: {
+        clerkId: `migrate-test-clerk-${unique}`,
+        email: `migrate-test-${unique}@example.com`,
+      },
+    })
+    userId = user.id
+    createdUserIds.push(userId)
+  })
+
+  afterEach(async () => {
+    // Cascade em User apaga projetos + planBlocks criados no teste.
+    while (createdUserIds.length) {
+      const id = createdUserIds.pop()!
+      await prisma.user.delete({ where: { id } }).catch(() => undefined)
+    }
+  })
+
+  // --------------------------------------------------------------------------
+  // Cenário 1: projeto com os 3 planos JSON → 14 PlanBlocks (6 + 4 + 4).
+  // --------------------------------------------------------------------------
+  it('migra projeto com os 3 planos completos para 14 PlanBlocks e preserva legacyPlans', async () => {
+    const project = await prisma.project.create({
+      data: {
+        userId,
+        name: 'Projeto completo',
+        businessPlan: sampleBusinessPlan,
+        technicalPlan: sampleTechnicalPlan,
+        uxPlan: sampleUxPlan,
+      },
+    })
+
+    const result = await migrate({
+      prisma,
+      logger: silentLogger,
+      projectId: project.id,
+    })
+
+    expect(result.migrated).toBe(1)
+    expect(result.skipped).toBe(0)
+    expect(result.blocksCreated).toBe(14)
+
+    const blocks = await prisma.planBlock.findMany({
+      where: { projectId: project.id },
+      orderBy: [{ planType: 'asc' }, { order: 'asc' }],
+    })
+
+    expect(blocks).toHaveLength(14)
+
+    const negocio = blocks.filter((b) => b.planType === 'NEGOCIO')
+    expect(negocio.map((b) => b.blockId)).toEqual([
+      'visao',
+      'problema',
+      'publico',
+      'features',
+      'diferenciais',
+      'monetizacao',
+    ])
+    expect(negocio[0].body).toContain('Cafeteria Bairro')
+    expect(negocio[1].body).toContain('rush')
+
+    const ux = blocks.filter((b) => b.planType === 'UX')
+    expect(ux.map((b) => b.blockId)).toEqual(['personas', 'jornadas', 'telas', 'tokens'])
+
+    const tecnico = blocks.filter((b) => b.planType === 'TECNICO')
+    expect(tecnico.map((b) => b.blockId)).toEqual([
+      'stack',
+      'arquitetura',
+      'dados',
+      'integracoes',
+    ])
+
+    // status = APPROVED e approvedAt preenchido.
+    expect(blocks.every((b) => b.status === 'APPROVED')).toBe(true)
+    expect(blocks.every((b) => b.approvedAt !== null)).toBe(true)
+
+    // legacyPlans preservado com o JSON original.
+    const updated = await prisma.project.findUniqueOrThrow({ where: { id: project.id } })
+    const legacy = updated.legacyPlans as {
+      businessPlan: typeof sampleBusinessPlan
+      technicalPlan: typeof sampleTechnicalPlan
+      uxPlan: typeof sampleUxPlan
+      migratedAt: string
+    }
+    expect(legacy.businessPlan.name).toBe('Cafeteria Bairro')
+    expect(legacy.technicalPlan.architecture.pattern).toBe('Monolito modular')
+    expect(legacy.uxPlan.personas).toHaveLength(1)
+    expect(typeof legacy.migratedAt).toBe('string')
+  })
+
+  // --------------------------------------------------------------------------
+  // Cenário 2: apenas businessPlan → 6 blocos NEGOCIO; outros planos não geram.
+  // --------------------------------------------------------------------------
+  it('migra apenas blocos correspondentes aos planos existentes', async () => {
+    const project = await prisma.project.create({
+      data: {
+        userId,
+        name: 'Só negocio',
+        businessPlan: sampleBusinessPlan,
+      },
+    })
+
+    const result = await migrate({
+      prisma,
+      logger: silentLogger,
+      projectId: project.id,
+    })
+
+    expect(result.migrated).toBe(1)
+    expect(result.blocksCreated).toBe(6)
+
+    const blocks = await prisma.planBlock.findMany({ where: { projectId: project.id } })
+    expect(blocks).toHaveLength(6)
+    expect(blocks.every((b) => b.planType === 'NEGOCIO')).toBe(true)
+  })
+
+  // --------------------------------------------------------------------------
+  // Cenário 3: idempotência — 2 runs seguidas, a segunda skipa.
+  // --------------------------------------------------------------------------
+  it('é idempotente: rodar duas vezes não duplica blocos', async () => {
+    const project = await prisma.project.create({
+      data: {
+        userId,
+        name: 'Idempotente',
+        businessPlan: sampleBusinessPlan,
+      },
+    })
+
+    const first = await migrate({
+      prisma,
+      logger: silentLogger,
+      projectId: project.id,
+    })
+    expect(first.migrated).toBe(1)
+    expect(first.blocksCreated).toBe(6)
+
+    const second = await migrate({
+      prisma,
+      logger: silentLogger,
+      projectId: project.id,
+    })
+    expect(second.migrated).toBe(0)
+    expect(second.skipped).toBe(1)
+    expect(second.blocksCreated).toBe(0)
+
+    const blocks = await prisma.planBlock.findMany({ where: { projectId: project.id } })
+    expect(blocks).toHaveLength(6)
+  })
+
+  // --------------------------------------------------------------------------
+  // Cenário 4: dry-run não persiste PlanBlocks nem toca legacyPlans.
+  // --------------------------------------------------------------------------
+  it('dry-run não persiste nenhum bloco nem preenche legacyPlans', async () => {
+    const project = await prisma.project.create({
+      data: {
+        userId,
+        name: 'Dry run',
+        businessPlan: sampleBusinessPlan,
+        uxPlan: sampleUxPlan,
+      },
+    })
+
+    const result = await migrate({
+      prisma,
+      logger: silentLogger,
+      projectId: project.id,
+      dryRun: true,
+    })
+
+    expect(result.dryRun).toBe(true)
+    expect(result.migrated).toBe(1)
+    expect(result.blocksCreated).toBe(10) // 6 NEGOCIO + 4 UX
+
+    const blocks = await prisma.planBlock.findMany({ where: { projectId: project.id } })
+    expect(blocks).toHaveLength(0)
+
+    const updated = await prisma.project.findUniqueOrThrow({ where: { id: project.id } })
+    expect(updated.legacyPlans).toBeNull()
+  })
+
+  // --------------------------------------------------------------------------
+  // Cenário 5: projeto sem planos antigos → skip sem efeito.
+  // --------------------------------------------------------------------------
+  it('pula projeto sem planos legados', async () => {
+    const project = await prisma.project.create({
+      data: {
+        userId,
+        name: 'Sem planos',
+      },
+    })
+
+    const result = await migrate({
+      prisma,
+      logger: silentLogger,
+      projectId: project.id,
+    })
+
+    // Com projectId explícito, o projeto é listado, mas como todos os planos
+    // são null, nenhum bloco é derivado e ele é contabilizado em "skipped".
+    expect(result.migrated).toBe(0)
+    expect(result.skipped).toBe(1)
+    expect(result.blocksCreated).toBe(0)
+
+    const blocks = await prisma.planBlock.findMany({ where: { projectId: project.id } })
+    expect(blocks).toHaveLength(0)
+  })
+
+  // --------------------------------------------------------------------------
+  // Cenário 6 (extra): dado malformado vai para fallback sem perder info.
+  // --------------------------------------------------------------------------
+  it('grava dump cru em bloco fallback quando o JSON é irreconhecível', async () => {
+    const project = await prisma.project.create({
+      data: {
+        userId,
+        name: 'Malformado',
+        businessPlan: { campoDesconhecido: 'valor arbitrário' },
+      },
+    })
+
+    const result = await migrate({
+      prisma,
+      logger: silentLogger,
+      projectId: project.id,
+    })
+
+    expect(result.migrated).toBe(1)
+    expect(result.blocksCreated).toBe(1)
+
+    const blocks = await prisma.planBlock.findMany({ where: { projectId: project.id } })
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].blockId).toBe('visao')
+    expect(blocks[0].body).toContain('campoDesconhecido')
+  })
+
+  // --------------------------------------------------------------------------
+  // Cenário 7 (extra): filtro global (sem projectId) pega só projetos com
+  // legacyPlans=null e algum plano não-null.
+  // --------------------------------------------------------------------------
+  it('sem projectId, migra apenas candidatos e ignora já migrados', async () => {
+    const naoMigrado = await prisma.project.create({
+      data: {
+        userId,
+        name: 'Não migrado',
+        businessPlan: sampleBusinessPlan,
+      },
+    })
+
+    const jaMigrado = await prisma.project.create({
+      data: {
+        userId,
+        name: 'Já migrado',
+        businessPlan: sampleBusinessPlan,
+        legacyPlans: { migratedAt: new Date().toISOString() },
+      },
+    })
+
+    const semPlanos = await prisma.project.create({
+      data: {
+        userId,
+        name: 'Sem planos',
+      },
+    })
+
+    const result = await migrate({ prisma, logger: silentLogger })
+
+    // Só o primeiro é candidato. Os outros são invisíveis ao filtro.
+    const blocksNaoMigrado = await prisma.planBlock.findMany({
+      where: { projectId: naoMigrado.id },
+    })
+    const blocksJaMigrado = await prisma.planBlock.findMany({
+      where: { projectId: jaMigrado.id },
+    })
+    const blocksSemPlanos = await prisma.planBlock.findMany({
+      where: { projectId: semPlanos.id },
+    })
+
+    expect(blocksNaoMigrado).toHaveLength(6)
+    expect(blocksJaMigrado).toHaveLength(0)
+    expect(blocksSemPlanos).toHaveLength(0)
+    expect(result.migrated).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/prisma/migrations/scripts/migrate-plans-to-blocks.ts
+++ b/prisma/migrations/scripts/migrate-plans-to-blocks.ts
@@ -1,0 +1,516 @@
+/**
+ * TRC-14.6 — Migração de dados: JSON blobs de planos → PlanBlock granular.
+ *
+ * Converte os campos legados `Project.businessPlan`, `Project.technicalPlan` e
+ * `Project.uxPlan` (JSON monolíticos) em blocos canônicos na tabela `PlanBlock`.
+ *
+ * Características:
+ * - Idempotente: projetos com `legacyPlans` já preenchido são pulados.
+ * - Preserva o JSON original em `Project.legacyPlans` (janela de 30 dias).
+ * - Assume planos antigos já aprovados → `status = APPROVED`, `approvedAt =
+ *   Project.updatedAt` como fallback.
+ * - Fallback seguro: se um bloco específico não for parseável, grava o JSON
+ *   cru em `body` e loga warning; nenhum dado é perdido.
+ *
+ * Uso:
+ *   npm run db:migrate:plans-to-blocks -- --dry-run
+ *   npm run db:migrate:plans-to-blocks -- --project-id=<id>
+ *   npm run db:migrate:plans-to-blocks
+ */
+
+import { PrismaClient, Prisma, PlanType, BlockStatus } from '@prisma/client'
+
+// ----------------------------------------------------------------------------
+// Mapa canônico de blocos (dos dados do mockup Spec/.../data.jsx)
+// ----------------------------------------------------------------------------
+
+interface BlockDef {
+  blockId: string
+  title: string
+  order: number
+}
+
+const BLOCK_DEFS: Record<PlanType, BlockDef[]> = {
+  NEGOCIO: [
+    { blockId: 'visao', title: 'Visão geral', order: 1 },
+    { blockId: 'problema', title: 'Problema', order: 2 },
+    { blockId: 'publico', title: 'Público-alvo', order: 3 },
+    { blockId: 'features', title: 'Features core', order: 4 },
+    { blockId: 'diferenciais', title: 'Diferenciais', order: 5 },
+    { blockId: 'monetizacao', title: 'Monetização', order: 6 },
+  ],
+  UX: [
+    { blockId: 'personas', title: 'Personas', order: 1 },
+    { blockId: 'jornadas', title: 'Jornadas', order: 2 },
+    { blockId: 'telas', title: 'Telas principais', order: 3 },
+    { blockId: 'tokens', title: 'Design tokens', order: 4 },
+  ],
+  TECNICO: [
+    { blockId: 'stack', title: 'Stack', order: 1 },
+    { blockId: 'arquitetura', title: 'Arquitetura', order: 2 },
+    { blockId: 'dados', title: 'Modelo de dados', order: 3 },
+    { blockId: 'integracoes', title: 'Integrações', order: 4 },
+  ],
+}
+
+// ----------------------------------------------------------------------------
+// Parser legacy — converte JSON blob em mapa { blockId -> body markdown }
+// ----------------------------------------------------------------------------
+
+type RawPlan = Record<string, unknown>
+
+/**
+ * Detecta se o valor é um objeto JSON indexável (não array, não null).
+ */
+function isRecord(value: unknown): value is RawPlan {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function stringifyJson(value: unknown): string {
+  return JSON.stringify(value, null, 2)
+}
+
+/**
+ * Converte um valor arbitrário numa string legível.
+ * - string: retorna direto (trim).
+ * - objeto/array: JSON.stringify formatado.
+ * - null/undefined: string vazia.
+ */
+function asBody(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value.trim()
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return stringifyJson(value)
+}
+
+/**
+ * Tenta fazer parse do plano legado para o shape canônico.
+ * Retorna um Map de blockId → body.
+ *
+ * Se a entrada for string (markdown monolítico), grava tudo no primeiro bloco.
+ * Se for objeto JSON mas não for parseável por chave, grava dump cru no
+ * primeiro bloco e loga warning.
+ */
+function parseLegacyPlan(
+  raw: unknown,
+  planType: PlanType,
+  logger: Logger,
+): Map<string, string> {
+  const bodies = new Map<string, string>()
+
+  if (raw === null || raw === undefined) {
+    return bodies
+  }
+
+  // Se veio string monolítica, grava no primeiro bloco como fallback.
+  if (typeof raw === 'string') {
+    const firstBlock = BLOCK_DEFS[planType][0]
+    logger.warn(
+      `Plano ${planType} veio como string — gravando conteúdo inteiro em "${firstBlock.blockId}".`,
+    )
+    bodies.set(firstBlock.blockId, raw.trim())
+    return bodies
+  }
+
+  if (!isRecord(raw)) {
+    const firstBlock = BLOCK_DEFS[planType][0]
+    logger.warn(
+      `Plano ${planType} em formato inesperado (${typeof raw}) — gravando dump em "${firstBlock.blockId}".`,
+    )
+    bodies.set(firstBlock.blockId, stringifyJson(raw))
+    return bodies
+  }
+
+  switch (planType) {
+    case 'NEGOCIO':
+      return parseBusinessPlan(raw, logger)
+    case 'UX':
+      return parseUxPlan(raw, logger)
+    case 'TECNICO':
+      return parseTechnicalPlan(raw, logger)
+  }
+}
+
+function parseBusinessPlan(raw: RawPlan, logger: Logger): Map<string, string> {
+  const bodies = new Map<string, string>()
+
+  // visao: name + tagline + description
+  const visaoParts: string[] = []
+  if (typeof raw.name === 'string' && raw.name.trim()) {
+    visaoParts.push(`# ${raw.name.trim()}`)
+  }
+  if (typeof raw.tagline === 'string' && raw.tagline.trim()) {
+    visaoParts.push(`_${raw.tagline.trim()}_`)
+  }
+  if (typeof raw.description === 'string' && raw.description.trim()) {
+    visaoParts.push(raw.description.trim())
+  }
+  if (visaoParts.length) bodies.set('visao', visaoParts.join('\n\n'))
+
+  // problema: problemStatement
+  if (typeof raw.problemStatement === 'string' && raw.problemStatement.trim()) {
+    bodies.set('problema', raw.problemStatement.trim())
+  }
+
+  // publico: targetAudience { primary, secondary?, painPoints }
+  if (isRecord(raw.targetAudience)) {
+    bodies.set('publico', asBody(raw.targetAudience))
+  }
+
+  // features: coreFeatures (+ niceToHaveFeatures anexadas como apêndice)
+  const featureParts: string[] = []
+  if (Array.isArray(raw.coreFeatures) && raw.coreFeatures.length) {
+    featureParts.push('## Must-have')
+    featureParts.push(stringifyJson(raw.coreFeatures))
+  }
+  if (Array.isArray(raw.niceToHaveFeatures) && raw.niceToHaveFeatures.length) {
+    featureParts.push('## Nice-to-have')
+    featureParts.push(stringifyJson(raw.niceToHaveFeatures))
+  }
+  if (featureParts.length) bodies.set('features', featureParts.join('\n\n'))
+
+  // diferenciais: competitors + successMetrics (agregação do que indica posicionamento)
+  const difParts: string[] = []
+  if (Array.isArray(raw.competitors) && raw.competitors.length) {
+    difParts.push('## Concorrentes e diferenciais')
+    difParts.push(stringifyJson(raw.competitors))
+  }
+  if (Array.isArray(raw.successMetrics) && raw.successMetrics.length) {
+    difParts.push('## Métricas de sucesso')
+    difParts.push(stringifyJson(raw.successMetrics))
+  }
+  if (difParts.length) bodies.set('diferenciais', difParts.join('\n\n'))
+
+  // monetizacao: monetization
+  if (isRecord(raw.monetization)) {
+    bodies.set('monetizacao', asBody(raw.monetization))
+  }
+
+  // Garante que pelo menos um bloco será criado; caso contrário, dump cru em visao.
+  if (bodies.size === 0) {
+    logger.warn(
+      'Plano NEGOCIO sem campos reconhecíveis — gravando dump cru em "visao".',
+    )
+    bodies.set('visao', stringifyJson(raw))
+  }
+
+  return bodies
+}
+
+function parseUxPlan(raw: RawPlan, logger: Logger): Map<string, string> {
+  const bodies = new Map<string, string>()
+
+  // personas: personas
+  if (Array.isArray(raw.personas) && raw.personas.length) {
+    bodies.set('personas', stringifyJson(raw.personas))
+  }
+
+  // jornadas: journeys
+  if (Array.isArray(raw.journeys) && raw.journeys.length) {
+    bodies.set('jornadas', stringifyJson(raw.journeys))
+  }
+
+  // telas: wireframes + informationArchitecture
+  const telasParts: string[] = []
+  if (isRecord(raw.informationArchitecture)) {
+    telasParts.push('## Arquitetura de informação')
+    telasParts.push(stringifyJson(raw.informationArchitecture))
+  }
+  if (Array.isArray(raw.wireframes) && raw.wireframes.length) {
+    telasParts.push('## Wireframes')
+    telasParts.push(stringifyJson(raw.wireframes))
+  }
+  if (telasParts.length) bodies.set('telas', telasParts.join('\n\n'))
+
+  // tokens: designTokens
+  if (isRecord(raw.designTokens)) {
+    bodies.set('tokens', asBody(raw.designTokens))
+  }
+
+  if (bodies.size === 0) {
+    logger.warn('Plano UX sem campos reconhecíveis — gravando dump cru em "personas".')
+    bodies.set('personas', stringifyJson(raw))
+  }
+
+  return bodies
+}
+
+function parseTechnicalPlan(raw: RawPlan, logger: Logger): Map<string, string> {
+  const bodies = new Map<string, string>()
+
+  // stack: stack
+  if (isRecord(raw.stack) || Array.isArray(raw.stack)) {
+    bodies.set('stack', asBody(raw.stack))
+  }
+
+  // arquitetura: architecture
+  if (isRecord(raw.architecture)) {
+    bodies.set('arquitetura', asBody(raw.architecture))
+  }
+
+  // dados: database + dataModel
+  const dadosParts: string[] = []
+  if (isRecord(raw.database)) {
+    dadosParts.push('## Database')
+    dadosParts.push(stringifyJson(raw.database))
+  }
+  if (isRecord(raw.dataModel)) {
+    dadosParts.push('## Modelo de dados')
+    dadosParts.push(stringifyJson(raw.dataModel))
+  }
+  if (dadosParts.length) bodies.set('dados', dadosParts.join('\n\n'))
+
+  // integracoes: integrations + apiEndpoints + realtime
+  const intParts: string[] = []
+  if (Array.isArray(raw.integrations) && raw.integrations.length) {
+    intParts.push('## Integrações externas')
+    intParts.push(stringifyJson(raw.integrations))
+  }
+  if (Array.isArray(raw.apiEndpoints) && raw.apiEndpoints.length) {
+    intParts.push('## API endpoints')
+    intParts.push(stringifyJson(raw.apiEndpoints))
+  }
+  if (isRecord(raw.realtime)) {
+    intParts.push('## Real-time')
+    intParts.push(stringifyJson(raw.realtime))
+  }
+  if (intParts.length) bodies.set('integracoes', intParts.join('\n\n'))
+
+  if (bodies.size === 0) {
+    logger.warn(
+      'Plano TECNICO sem campos reconhecíveis — gravando dump cru em "stack".',
+    )
+    bodies.set('stack', stringifyJson(raw))
+  }
+
+  return bodies
+}
+
+// ----------------------------------------------------------------------------
+// Logger (injetável para testes)
+// ----------------------------------------------------------------------------
+
+export interface Logger {
+  info: (msg: string) => void
+  warn: (msg: string) => void
+  error: (msg: string) => void
+}
+
+const consoleLogger: Logger = {
+  info: (msg) => console.log(msg),
+  warn: (msg) => console.warn(`[warn] ${msg}`),
+  error: (msg) => console.error(`[error] ${msg}`),
+}
+
+// ----------------------------------------------------------------------------
+// Orquestrador principal
+// ----------------------------------------------------------------------------
+
+export interface MigrateOptions {
+  dryRun?: boolean
+  projectId?: string
+  prisma?: PrismaClient
+  logger?: Logger
+}
+
+export interface MigrateResult {
+  totalProjects: number
+  migrated: number
+  skipped: number
+  blocksCreated: number
+  dryRun: boolean
+}
+
+export async function migrate(options: MigrateOptions = {}): Promise<MigrateResult> {
+  const logger = options.logger ?? consoleLogger
+  const prisma = options.prisma ?? new PrismaClient()
+  const ownsPrisma = !options.prisma
+  const dryRun = options.dryRun ?? false
+
+  const result: MigrateResult = {
+    totalProjects: 0,
+    migrated: 0,
+    skipped: 0,
+    blocksCreated: 0,
+    dryRun,
+  }
+
+  try {
+    const where: Prisma.ProjectWhereInput = options.projectId
+      ? { id: options.projectId }
+      : {
+          OR: [
+            { businessPlan: { not: Prisma.DbNull } },
+            { technicalPlan: { not: Prisma.DbNull } },
+            { uxPlan: { not: Prisma.DbNull } },
+          ],
+          legacyPlans: { equals: Prisma.DbNull },
+        }
+
+    const projects = await prisma.project.findMany({
+      where,
+      select: {
+        id: true,
+        name: true,
+        businessPlan: true,
+        technicalPlan: true,
+        uxPlan: true,
+        legacyPlans: true,
+        updatedAt: true,
+      },
+    })
+
+    result.totalProjects = projects.length
+    logger.info(
+      `Projetos candidatos à migração: ${projects.length}${dryRun ? ' (dry-run)' : ''}.`,
+    )
+
+    for (const project of projects) {
+      // Idempotência: se já existe snapshot legado, pula.
+      if (project.legacyPlans !== null && project.legacyPlans !== undefined) {
+        logger.info(
+          `Projeto ${project.id} (${project.name}): já migrado (legacyPlans preenchido), pulando.`,
+        )
+        result.skipped++
+        continue
+      }
+
+      const approvedAt = project.updatedAt
+
+      const blocksToCreate: Array<{
+        planType: PlanType
+        blockId: string
+        title: string
+        order: number
+        body: string
+      }> = []
+
+      const planSources: Array<{ planType: PlanType; raw: unknown }> = [
+        { planType: PlanType.NEGOCIO, raw: project.businessPlan },
+        { planType: PlanType.UX, raw: project.uxPlan },
+        { planType: PlanType.TECNICO, raw: project.technicalPlan },
+      ]
+
+      for (const { planType, raw } of planSources) {
+        if (raw === null || raw === undefined) continue
+
+        const bodyMap = parseLegacyPlan(raw, planType, logger)
+        if (bodyMap.size === 0) continue
+
+        for (const def of BLOCK_DEFS[planType]) {
+          const body = bodyMap.get(def.blockId)
+          if (!body) continue
+          blocksToCreate.push({
+            planType,
+            blockId: def.blockId,
+            title: def.title,
+            order: def.order,
+            body,
+          })
+        }
+      }
+
+      if (blocksToCreate.length === 0) {
+        logger.info(
+          `Projeto ${project.id} (${project.name}): nenhum bloco derivado dos planos existentes, pulando.`,
+        )
+        result.skipped++
+        continue
+      }
+
+      if (dryRun) {
+        logger.info(
+          `Projeto ${project.id} (${project.name}): [dry-run] ${blocksToCreate.length} blocos seriam criados.`,
+        )
+        result.migrated++
+        result.blocksCreated += blocksToCreate.length
+        continue
+      }
+
+      // Snapshot legado — preserva o JSON original para rollback.
+      const legacySnapshot: Prisma.InputJsonValue = {
+        migratedAt: new Date().toISOString(),
+        businessPlan: (project.businessPlan ?? null) as Prisma.InputJsonValue,
+        technicalPlan: (project.technicalPlan ?? null) as Prisma.InputJsonValue,
+        uxPlan: (project.uxPlan ?? null) as Prisma.InputJsonValue,
+      }
+
+      await prisma.$transaction(async (tx) => {
+        await tx.project.update({
+          where: { id: project.id },
+          data: { legacyPlans: legacySnapshot },
+        })
+
+        for (const block of blocksToCreate) {
+          await tx.planBlock.create({
+            data: {
+              projectId: project.id,
+              planType: block.planType,
+              blockId: block.blockId,
+              title: block.title,
+              order: block.order,
+              body: block.body,
+              status: BlockStatus.APPROVED,
+              approvedAt,
+            },
+          })
+        }
+      })
+
+      logger.info(
+        `Projeto ${project.id} (${project.name}): migrado — ${blocksToCreate.length} blocos criados.`,
+      )
+      result.migrated++
+      result.blocksCreated += blocksToCreate.length
+    }
+
+    logger.info(
+      `Migração ${dryRun ? 'dry-run ' : ''}concluída: ${result.migrated} migrados, ${result.skipped} pulados, ${result.blocksCreated} blocos criados.`,
+    )
+  } finally {
+    if (ownsPrisma) {
+      await prisma.$disconnect()
+    }
+  }
+
+  return result
+}
+
+// ----------------------------------------------------------------------------
+// CLI entrypoint
+// ----------------------------------------------------------------------------
+
+function parseArgs(argv: string[]): MigrateOptions {
+  const options: MigrateOptions = {}
+  for (const arg of argv) {
+    if (arg === '--dry-run') {
+      options.dryRun = true
+    } else if (arg.startsWith('--project-id=')) {
+      options.projectId = arg.slice('--project-id='.length)
+    }
+  }
+  return options
+}
+
+// Detecta execução direta vs import (em testes).
+// import.meta.url começa com file:// quando executado via tsx/node.
+const isDirectRun =
+  typeof process !== 'undefined' &&
+  Array.isArray(process.argv) &&
+  process.argv[1] &&
+  import.meta.url === `file://${process.argv[1]}`
+
+if (isDirectRun) {
+  const options = parseArgs(process.argv.slice(2))
+  migrate(options)
+    .then((result) => {
+      if (result.totalProjects === 0) {
+        consoleLogger.info('Nenhum projeto candidato encontrado.')
+      }
+      process.exit(0)
+    })
+    .catch((err) => {
+      consoleLogger.error(`Falha na migração: ${err instanceof Error ? err.message : String(err)}`)
+      process.exit(1)
+    })
+}


### PR DESCRIPTION
## Summary

Script idempotente de migração de dados: converte `Project.businessPlan/technicalPlan/uxPlan` (JSON blobs legacy) para `PlanBlock` granular introduzido em TRC-14.5. Preserva original em `Project.legacyPlans` por 30 dias pra rollback.

6ª sub-task do TRC-14 Fundação.

Notion: [TRC-14.6](https://www.notion.so/34b0d9578db3811f88e0deffcdf088a0) · [TRC-14 épico](https://www.notion.so/34b0d9578db3813e860ecacb4a83055e)

## Escopo

- **`prisma/migrations/scripts/migrate-plans-to-blocks.ts`** — CLI com `--dry-run` e `--project-id=<id>`. Mapeia shapes legacy (src/types BusinessPlan + src/lib/ai/prompts TechnicalPlan/UXPlan) para 14 blocos canônicos (6 Negócio + 4 UX + 4 Técnico) do mockup `Spec/Jornada Coleta inicial/src/data.jsx`. Fallback em camadas pra dados malformados.
- **`prisma/migrations/scripts/migrate-plans-to-blocks.test.ts`** — 7 cenários de integração (skipam se DB off): 3 planos→14 blocos, só Negócio→6, idempotência, dry-run, sem planos, malformado, filtro global.
- **`docs/migrations/2026-04-plans-to-blocks.md`** — runbook completo: dev vs prod, rollback, janela retenção, mapeamento.
- **`package.json`** — script `db:migrate:plans-to-blocks` + `tsx` como devDep.

## Propriedades importantes

- **Idempotente**: skipa projetos com `legacyPlans != null` (já migrados).
- **Atômico**: transação Prisma por projeto — tudo ou nada.
- **Preserva original**: `legacyPlans` Json recebe `{ business, technical, ux }` cru antes dos blocos serem criados.
- **Status inicial APPROVED**: assume planos antigos estavam aprovados (única razão pra existirem em JSON).
- **approvedAt = Project.updatedAt**: fallback razoável sem campo próprio no legacy.

## Não está neste PR

- Drop das colunas legacy `Project.businessPlan/technicalPlan/uxPlan` — fica pra PR futuro após 30 dias de observação em prod.
- UI consumindo `PlanBlock` — TRC-18.
- Seed canônico Maria — TRC-14.7 (depende deste).

## Test plan

- [x] `npx prisma validate` OK
- [x] `npm run lint` limpo
- [x] `npm run build` passa
- [x] `npm test` — 583/583 (7 novos)
- [x] `npm run db:migrate:plans-to-blocks -- --dry-run` executa sem erro (0 candidatos em dev local)
- [ ] Rodar `--dry-run` em preview/staging com dados reais antes do run definitivo
- [ ] Validar mapeamento visual: abrir projeto migrado + conferir blocos granulares batendo com conteúdo original

🤖 Generated with [Claude Code](https://claude.com/claude-code)