### PR TITLE
feat(seed): fixtures canônicas Maria/Cafeteria Beta (TRC-14.7)

### DIFF
--- a/docs/seeds/maria.md
+++ b/docs/seeds/maria.md
@@ -82,5 +82,5 @@ A migração `migrate-plans-to-blocks` (TRC-14.6) converte projetos **existentes
 ## Limitações conhecidas
 
 - **`CB-RISK-001 Category`**: o mockup `data-risks.jsx` marca a categoria como "Pagamentos", que não existe no enum `RiskCategory` do schema. Mapeamos para `TECNICO` (risco técnico de integração). Se o schema ganhar `PAGAMENTOS` como categoria, atualizar fixture.
-- **`CB-RISK-002 Category`**: mockup marca "Operacional", também inexistente no enum. Mapeado para `MERCADO` (reflete a quebra de confiança do cliente).
+- **`CB-RISK-002 Category`**: mockup marca "Operacional", também inexistente no enum. Mapeado para `REPUTACAO` — o vetor primário é dano de confiança do cliente (quem paga e não recebe), não disputa de mercado.
 - Identificadores `CB-DEC-001`, `CB-DEC-002`, `CB-RISK-001`, `CB-RISK-002` ainda não são persistidos — drafts não têm `publicId` no schema, só `Decision`/`Risk` registrados. Os códigos propostos vivem na fixture como `proposedPublicId` para quando forem promovidos.

--- a/docs/seeds/maria.md
+++ b/docs/seeds/maria.md
@@ -1,0 +1,86 @@
+# Seed: Maria Silva / Cafeteria Beta
+
+**Ticket:** TRC-14.7
+**Script:** `prisma/seed-maria.ts`
+**Fixtures (single source of truth):** `src/test/fixtures/maria-canonical.ts`
+**Epic:** TRC-14 — Fundação da plataforma
+
+## O que este seed cria
+
+Popula o banco com o estado canônico da Maria em modo **"projeto exportado v1.0"** — tudo aprovado, pronto para demo/inspeção da UI:
+
+| Entidade | Qtd | Observação |
+| --- | --- | --- |
+| `User` | 1 | `clerkId=seed-maria-clerk-id`, `personaTag=FOUNDER`, `workspaceMode=SOLO` |
+| `CreditLedger` | 1 | `balance=1`, `tier=TRIAL` (resíduo pós-jornada) |
+| `ProductContext` | 1 | 9 campos POLICY-010 preenchidos, 3 bets, 4 assumptions |
+| `Project` | 1 | `phase=ESPECIFICACAO`, `stageKey=exportar`, `version=v1.0` |
+| `PlanBlock` | 14 | 6 NEGOCIO + 4 UX + 4 TECNICO, todos `APPROVED` |
+| `DecisionDraft` | 2 | `CB-DEC-001` e `CB-DEC-002` (pending, Inbox) |
+| `RiskDraft` | 2 | `CB-RISK-001` e `CB-RISK-002` (pending, Inbox) |
+| `Decision` | 0 | Deliberado — drafts aguardam triagem |
+| `Risk` | 0 | Deliberado — drafts aguardam triagem |
+
+Conteúdo vem de `Spec/Jornada Coleta inicial/src/data.jsx` e `data-risks.jsx` (mockups canônicos do produto) — qualquer drift exige atualizar fixture **e** mockup juntos.
+
+## Quando usar
+
+- **Testes manuais** da UI em dev: abrir qualquer tela da Fase Especificação já com 14 blocos, Inbox populada e Product Context completo.
+- **Demos internas**: apresentar o produto para stakeholders com dados realistas e consistentes.
+- **Reuso em testes unitários**: `src/test/fixtures/maria-canonical.ts` expõe os mesmos objetos consumidos pelo seed — componentes React e serviços podem importar sem precisar tocar no DB.
+
+## Como rodar
+
+### Dev local
+
+```bash
+# Pré-requisito: DATABASE_URL apontando para um DB acessível (.env.local).
+npm run db:seed:maria
+```
+
+Saída esperada (primeira run):
+
+```
+User Maria: <cuid> (criado).
+Project Cafeteria Beta Pedidos: <cuid> (criado).
+Seed Maria concluído: user=<cuid>, project=<cuid>, planBlocksCriados=14/14, decisionDraftsCriados=2/2, riskDraftsCriados=2/2.
+```
+
+### Idempotência
+
+Pode rodar N vezes sem duplicar. Todas as entidades usam upsert por chaves estáveis:
+
+- `User` → `clerkId=seed-maria-clerk-id` (unique).
+- `CreditLedger` / `ProductContext` → `userId` (unique).
+- `Project` → `findFirst({ userId, name })` + create-if-missing.
+- `PlanBlock` → `[projectId, planType, blockId]` composite unique.
+- `DecisionDraft` / `RiskDraft` → `findFirst({ projectId, title })` + create-if-missing (não há unique no schema; dedup a nível de seed).
+
+Re-runs preservam edições manuais feitas no Prisma Studio (blocos em `update: {}` são no-op).
+
+## Como resetar
+
+O seed não tem `--reset`; use SQL direto para limpar:
+
+```sql
+DELETE FROM users WHERE "clerkId" = 'seed-maria-clerk-id';
+-- Cascade limpa Project, PlanBlock, DecisionDraft, RiskDraft, ProductContext, CreditLedger.
+```
+
+Depois rode `npm run db:seed:maria` novamente para recriar do zero.
+
+## Relação com TRC-14.6
+
+A migração `migrate-plans-to-blocks` (TRC-14.6) converte projetos **existentes** de JSON legado para PlanBlock. Este seed **não usa** aquele script — cria PlanBlocks diretamente a partir das fixtures canônicas, que é o formato final. Os dois coexistem: migração lida com histórico; seed cria estado novo para dev/testes.
+
+## Testes
+
+- `prisma/seed-maria.test.ts` — testes de integração contra o DB configurado.
+- Skipa graciosamente se DB não está acessível (padrão de `prisma/schema.test.ts`).
+- Cobertura: cria estado completo; idempotência (2 runs, sem duplicação); metadata do Project; PlanBlocks APPROVED e alinhados à fixture byte a byte.
+
+## Limitações conhecidas
+
+- **`CB-RISK-001 Category`**: o mockup `data-risks.jsx` marca a categoria como "Pagamentos", que não existe no enum `RiskCategory` do schema. Mapeamos para `TECNICO` (risco técnico de integração). Se o schema ganhar `PAGAMENTOS` como categoria, atualizar fixture.
+- **`CB-RISK-002 Category`**: mockup marca "Operacional", também inexistente no enum. Mapeado para `MERCADO` (reflete a quebra de confiança do cliente).
+- Identificadores `CB-DEC-001`, `CB-DEC-002`, `CB-RISK-001`, `CB-RISK-002` ainda não são persistidos — drafts não têm `publicId` no schema, só `Decision`/`Risk` registrados. Os códigos propostos vivem na fixture como `proposedPublicId` para quando forem promovidos.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
     "db:studio": "prisma studio",
-    "db:migrate:plans-to-blocks": "tsx prisma/migrations/scripts/migrate-plans-to-blocks.ts"
+    "db:migrate:plans-to-blocks": "tsx prisma/migrations/scripts/migrate-plans-to-blocks.ts",
+    "db:seed:maria": "tsx prisma/seed-maria.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",

--- a/prisma/seed-maria.test.ts
+++ b/prisma/seed-maria.test.ts
@@ -53,10 +53,7 @@ async function resetMaria(): Promise<void> {
 }
 
 describeIfDb('seed-maria', () => {
-  beforeAll(async () => {
-    await prisma.$connect()
-  })
-
+  // $connect já aconteceu no probe top-level — sem double-connect.
   afterAll(async () => {
     await prisma.$disconnect()
   })

--- a/prisma/seed-maria.test.ts
+++ b/prisma/seed-maria.test.ts
@@ -109,15 +109,20 @@ describeIfDb('seed-maria', () => {
       where: { projectId: result.projectId },
     })
     expect(decisionDrafts).toHaveLength(2)
-    const draftTitles = decisionDrafts.map((d) => d.title).sort()
-    expect(draftTitles).toEqual(MARIA_DECISION_DRAFTS.map((d) => d.title).sort())
+    const byLocale = (a: string, b: string) => a.localeCompare(b, 'pt-BR')
+    const draftTitles = decisionDrafts.map((d) => d.title).sort(byLocale)
+    expect(draftTitles).toEqual(
+      MARIA_DECISION_DRAFTS.map((d) => d.title).sort(byLocale),
+    )
 
     const riskDrafts = await prisma.riskDraft.findMany({
       where: { projectId: result.projectId },
     })
     expect(riskDrafts).toHaveLength(2)
-    const riskTitles = riskDrafts.map((r) => r.title).sort()
-    expect(riskTitles).toEqual(MARIA_RISK_DRAFTS.map((r) => r.title).sort())
+    const riskTitles = riskDrafts.map((r) => r.title).sort(byLocale)
+    expect(riskTitles).toEqual(
+      MARIA_RISK_DRAFTS.map((r) => r.title).sort(byLocale),
+    )
 
     // Estado pós-export deliberado: drafts na Inbox; nenhum Decision/Risk registrado.
     const decisions = await prisma.decision.count({ where: { projectId: result.projectId } })

--- a/prisma/seed-maria.test.ts
+++ b/prisma/seed-maria.test.ts
@@ -1,0 +1,235 @@
+/**
+ * TRC-14.7 — Testes de integração do seed Maria/Cafeteria Beta.
+ *
+ * Rodam contra o DATABASE_URL configurado, seguindo o padrão de
+ * prisma/schema.test.ts: se o DB não estiver acessível, a suite é skipada.
+ *
+ * Limpam o estado por clerkId fixo antes e depois para não vazar entre suites.
+ */
+
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import { PrismaClient } from '@prisma/client'
+
+import { seedMaria, type Logger } from './seed-maria'
+import {
+  MARIA_ALL_BLOCKS,
+  MARIA_BLOCK_STATUS,
+  MARIA_CLERK_ID,
+  MARIA_DECISION_DRAFTS,
+  MARIA_PROJECT,
+  MARIA_RISK_DRAFTS,
+} from '../src/test/fixtures/maria-canonical'
+
+const prisma = new PrismaClient({ log: ['error'] })
+
+// Probe DB — se falha, pula toda a suite.
+let dbReachable = false
+try {
+  await prisma.$connect()
+  await prisma.$queryRawUnsafe('SELECT 1')
+  dbReachable = true
+} catch {
+  dbReachable = false
+}
+
+const describeIfDb = dbReachable ? describe : describe.skip
+
+const silentLogger: Logger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+}
+
+/**
+ * Deleta o user Maria (cascade limpa projeto + blocos + drafts + context + ledger).
+ * Usado antes e depois de cada teste para garantir isolamento.
+ *
+ * Usa deleteMany para ser no-op silenciosamente quando o registro já não existe
+ * — evita ruído de "record not found" no stderr do Prisma.
+ */
+async function resetMaria(): Promise<void> {
+  await prisma.user.deleteMany({ where: { clerkId: MARIA_CLERK_ID } })
+}
+
+describeIfDb('seed-maria', () => {
+  beforeAll(async () => {
+    await prisma.$connect()
+  })
+
+  afterAll(async () => {
+    await prisma.$disconnect()
+  })
+
+  beforeEach(async () => {
+    await resetMaria()
+  })
+
+  afterEach(async () => {
+    await resetMaria()
+  })
+
+  // --------------------------------------------------------------------------
+  // Cenário 1: run limpo cria todo o estado canônico.
+  // --------------------------------------------------------------------------
+  it('cria User + ProductContext + CreditLedger + Project + 14 PlanBlocks + 2 DecisionDrafts + 2 RiskDrafts', async () => {
+    const result = await seedMaria({ prisma, logger: silentLogger })
+
+    expect(result.created.user).toBe(true)
+    expect(result.created.productContext).toBe(true)
+    expect(result.created.creditLedger).toBe(true)
+    expect(result.created.project).toBe(true)
+    expect(result.created.planBlocks).toBe(14)
+    expect(result.created.decisionDrafts).toBe(2)
+    expect(result.created.riskDrafts).toBe(2)
+
+    const user = await prisma.user.findUnique({ where: { clerkId: MARIA_CLERK_ID } })
+    expect(user).not.toBeNull()
+    expect(user!.personaTag).toBe('FOUNDER')
+    expect(user!.workspaceMode).toBe('SOLO')
+
+    const ledger = await prisma.creditLedger.findUnique({ where: { userId: user!.id } })
+    expect(ledger).not.toBeNull()
+    expect(ledger!.balance).toBe(1)
+    expect(ledger!.tier).toBe('TRIAL')
+
+    const context = await prisma.productContext.findUnique({ where: { userId: user!.id } })
+    expect(context).not.toBeNull()
+    expect(context!.stage).toBe('PRE_PRODUCT')
+    expect(context!.reviewCadence).toBe('QUARTERLY')
+    const bets = context!.strategicBets as string[]
+    expect(bets.length).toBeGreaterThanOrEqual(2)
+    const assumptions = context!.openAssumptions as Array<{ category: string }>
+    expect(assumptions.length).toBeGreaterThanOrEqual(3)
+
+    const blocks = await prisma.planBlock.findMany({
+      where: { projectId: result.projectId },
+      orderBy: [{ planType: 'asc' }, { order: 'asc' }],
+    })
+    expect(blocks).toHaveLength(14)
+
+    const decisionDrafts = await prisma.decisionDraft.findMany({
+      where: { projectId: result.projectId },
+    })
+    expect(decisionDrafts).toHaveLength(2)
+    const draftTitles = decisionDrafts.map((d) => d.title).sort()
+    expect(draftTitles).toEqual(MARIA_DECISION_DRAFTS.map((d) => d.title).sort())
+
+    const riskDrafts = await prisma.riskDraft.findMany({
+      where: { projectId: result.projectId },
+    })
+    expect(riskDrafts).toHaveLength(2)
+    const riskTitles = riskDrafts.map((r) => r.title).sort()
+    expect(riskTitles).toEqual(MARIA_RISK_DRAFTS.map((r) => r.title).sort())
+
+    // Estado pós-export deliberado: drafts na Inbox; nenhum Decision/Risk registrado.
+    const decisions = await prisma.decision.count({ where: { projectId: result.projectId } })
+    const risks = await prisma.risk.count({ where: { projectId: result.projectId } })
+    expect(decisions).toBe(0)
+    expect(risks).toBe(0)
+  })
+
+  // --------------------------------------------------------------------------
+  // Cenário 2: idempotência — segunda run não duplica nada.
+  // --------------------------------------------------------------------------
+  it('é idempotente: rodar duas vezes não duplica entidades', async () => {
+    const first = await seedMaria({ prisma, logger: silentLogger })
+    expect(first.created.user).toBe(true)
+    expect(first.created.planBlocks).toBe(14)
+
+    const second = await seedMaria({ prisma, logger: silentLogger })
+    expect(second.created.user).toBe(false)
+    expect(second.created.productContext).toBe(false)
+    expect(second.created.creditLedger).toBe(false)
+    expect(second.created.project).toBe(false)
+    expect(second.created.planBlocks).toBe(0)
+    expect(second.created.decisionDrafts).toBe(0)
+    expect(second.created.riskDrafts).toBe(0)
+
+    // Mesmas ids — confirma upsert/find em vez de create duplicado.
+    expect(second.userId).toBe(first.userId)
+    expect(second.projectId).toBe(first.projectId)
+
+    // Contagens totais no DB para o escopo Maria permanecem as mesmas.
+    const projects = await prisma.project.count({ where: { userId: first.userId } })
+    const blocks = await prisma.planBlock.count({ where: { projectId: first.projectId } })
+    const decisionDrafts = await prisma.decisionDraft.count({
+      where: { projectId: first.projectId },
+    })
+    const riskDrafts = await prisma.riskDraft.count({
+      where: { projectId: first.projectId },
+    })
+    expect(projects).toBe(1)
+    expect(blocks).toBe(14)
+    expect(decisionDrafts).toBe(2)
+    expect(riskDrafts).toBe(2)
+  })
+
+  // --------------------------------------------------------------------------
+  // Cenário 3: Project tem metadata de pós-export v1.0.
+  // --------------------------------------------------------------------------
+  it('Project tem stageKey=exportar, version=v1.0, phase=ESPECIFICACAO', async () => {
+    const result = await seedMaria({ prisma, logger: silentLogger })
+    const project = await prisma.project.findUniqueOrThrow({
+      where: { id: result.projectId },
+    })
+    expect(project.name).toBe(MARIA_PROJECT.name)
+    expect(project.phase).toBe('ESPECIFICACAO')
+    expect(project.stageKey).toBe('exportar')
+    expect(project.version).toBe('v1.0')
+  })
+
+  // --------------------------------------------------------------------------
+  // Cenário 4: todos os PlanBlocks estão APPROVED (estado pós-export).
+  // --------------------------------------------------------------------------
+  it('todos os PlanBlocks estão APPROVED com approvedAt preenchido e respeitam a ordem canônica', async () => {
+    const result = await seedMaria({ prisma, logger: silentLogger })
+
+    const blocks = await prisma.planBlock.findMany({
+      where: { projectId: result.projectId },
+      orderBy: [{ planType: 'asc' }, { order: 'asc' }],
+    })
+
+    expect(blocks).toHaveLength(14)
+    expect(blocks.every((b) => b.status === MARIA_BLOCK_STATUS)).toBe(true)
+    expect(blocks.every((b) => b.approvedAt !== null)).toBe(true)
+
+    // Contagem por plano.
+    const negocio = blocks.filter((b) => b.planType === 'NEGOCIO')
+    const ux = blocks.filter((b) => b.planType === 'UX')
+    const tecnico = blocks.filter((b) => b.planType === 'TECNICO')
+    expect(negocio).toHaveLength(6)
+    expect(ux).toHaveLength(4)
+    expect(tecnico).toHaveLength(4)
+
+    // Ordem e blockIds batem com a fixture (single source of truth).
+    expect(negocio.map((b) => b.blockId)).toEqual([
+      'visao',
+      'problema',
+      'publico',
+      'features',
+      'diferenciais',
+      'monetizacao',
+    ])
+    expect(ux.map((b) => b.blockId)).toEqual(['personas', 'jornadas', 'telas', 'tokens'])
+    expect(tecnico.map((b) => b.blockId)).toEqual(['stack', 'arquitetura', 'dados', 'integracoes'])
+
+    // Bodies carregam acentuação pt-BR (Regra CLAUDE.md #6).
+    const visao = negocio.find((b) => b.blockId === 'visao')!
+    expect(visao.body).toContain('Cafeteria Beta Pedidos')
+    const problema = negocio.find((b) => b.blockId === 'problema')!
+    expect(problema.body).toContain('não')
+    expect(problema.body).toContain('15 a 20')
+
+    // Alinhamento com a fixture export — bytes iguais por blockId.
+    for (const fixture of MARIA_ALL_BLOCKS) {
+      const db = blocks.find(
+        (b) => b.planType === fixture.planType && b.blockId === fixture.blockId,
+      )
+      expect(db, `bloco ${fixture.planType}/${fixture.blockId} deve existir no DB`).toBeDefined()
+      expect(db!.title).toBe(fixture.title)
+      expect(db!.body).toBe(fixture.body)
+      expect(db!.order).toBe(fixture.order)
+    }
+  })
+})

--- a/prisma/seed-maria.ts
+++ b/prisma/seed-maria.ts
@@ -1,0 +1,321 @@
+/**
+ * TRC-14.7 — Seed Maria/Cafeteria Beta.
+ *
+ * Cria o estado canônico da Maria em modo "projeto exportado v1.0":
+ * User + CreditLedger + ProductContext + Project + 14 PlanBlocks (APPROVED)
+ * + 2 DecisionDrafts (pending) + 2 RiskDrafts (pending).
+ *
+ * Idempotente: upsert por clerkId/userId/composite unique; re-runs não duplicam.
+ *
+ * Uso: `npm run db:seed:maria`.
+ * Reset: `DELETE FROM users WHERE "clerkId" = 'seed-maria-clerk-id' CASCADE;`
+ *
+ * Fixtures são re-exportadas em `src/test/fixtures/maria-canonical.ts`
+ * — single source of truth entre seed e testes unitários.
+ */
+
+import { PrismaClient, PersonaTag, WorkspaceMode } from '@prisma/client'
+import type { Prisma } from '@prisma/client'
+
+import {
+  MARIA_ALL_BLOCKS,
+  MARIA_BLOCK_STATUS,
+  MARIA_CLERK_ID,
+  MARIA_CREDIT_LEDGER,
+  MARIA_DECISION_DRAFTS,
+  MARIA_PRODUCT_CONTEXT,
+  MARIA_PROJECT,
+  MARIA_RISK_DRAFTS,
+  MARIA_USER,
+} from '../src/test/fixtures/maria-canonical'
+
+// ----------------------------------------------------------------------------
+// Logger (injetável para testes)
+// ----------------------------------------------------------------------------
+
+export interface Logger {
+  info: (msg: string) => void
+  warn: (msg: string) => void
+  error: (msg: string) => void
+}
+
+const consoleLogger: Logger = {
+  info: (msg) => console.log(msg),
+  warn: (msg) => console.warn(`[warn] ${msg}`),
+  error: (msg) => console.error(`[error] ${msg}`),
+}
+
+// ----------------------------------------------------------------------------
+// Orquestrador
+// ----------------------------------------------------------------------------
+
+export interface SeedOptions {
+  prisma?: PrismaClient
+  logger?: Logger
+}
+
+export interface SeedResult {
+  userId: string
+  projectId: string
+  created: {
+    user: boolean
+    productContext: boolean
+    creditLedger: boolean
+    project: boolean
+    planBlocks: number
+    decisionDrafts: number
+    riskDrafts: number
+  }
+}
+
+/**
+ * Busca o projeto canônico da Maria por (userId, name).
+ * Usa findFirst porque `name` não é unique no schema; na prática, é único
+ * dentro do escopo deste seed (só esta função cria um projeto com esse nome
+ * para esse user).
+ */
+async function findMariaProject(
+  prisma: PrismaClient,
+  userId: string,
+): Promise<{ id: string } | null> {
+  return prisma.project.findFirst({
+    where: { userId, name: MARIA_PROJECT.name },
+    select: { id: true },
+  })
+}
+
+export async function seedMaria(options: SeedOptions = {}): Promise<SeedResult> {
+  const logger = options.logger ?? consoleLogger
+  const prisma = options.prisma ?? new PrismaClient()
+  const ownsPrisma = !options.prisma
+
+  const created = {
+    user: false,
+    productContext: false,
+    creditLedger: false,
+    project: false,
+    planBlocks: 0,
+    decisionDrafts: 0,
+    riskDrafts: 0,
+  }
+
+  try {
+    // ------------------------------------------------------------------------
+    // 1. User (idempotente por clerkId fixo)
+    // ------------------------------------------------------------------------
+    const existingUser = await prisma.user.findUnique({
+      where: { clerkId: MARIA_CLERK_ID },
+      select: { id: true },
+    })
+    created.user = !existingUser
+
+    const user = await prisma.user.upsert({
+      where: { clerkId: MARIA_CLERK_ID },
+      create: {
+        clerkId: MARIA_USER.clerkId,
+        email: MARIA_USER.email,
+        name: MARIA_USER.name,
+        personaTag: PersonaTag.FOUNDER,
+        workspaceMode: WorkspaceMode.SOLO,
+      },
+      // No-op no update — preserva edições manuais do dev que possam ter
+      // sido feitas para testar fluxos pontuais no Prisma Studio.
+      update: {},
+      select: { id: true },
+    })
+    logger.info(`User Maria: ${user.id} (${created.user ? 'criado' : 'já existia'}).`)
+
+    // ------------------------------------------------------------------------
+    // 2. CreditLedger (1:1 com User por userId unique)
+    // ------------------------------------------------------------------------
+    const existingLedger = await prisma.creditLedger.findUnique({
+      where: { userId: user.id },
+      select: { id: true },
+    })
+    created.creditLedger = !existingLedger
+
+    await prisma.creditLedger.upsert({
+      where: { userId: user.id },
+      create: {
+        userId: user.id,
+        balance: MARIA_CREDIT_LEDGER.balance,
+        tier: MARIA_CREDIT_LEDGER.tier,
+      },
+      update: {},
+    })
+
+    // ------------------------------------------------------------------------
+    // 3. ProductContext (1:1 com User por userId unique)
+    // ------------------------------------------------------------------------
+    const existingContext = await prisma.productContext.findUnique({
+      where: { userId: user.id },
+      select: { id: true },
+    })
+    created.productContext = !existingContext
+
+    await prisma.productContext.upsert({
+      where: { userId: user.id },
+      create: {
+        userId: user.id,
+        userSegment: MARIA_PRODUCT_CONTEXT.userSegment,
+        primaryJtbd: MARIA_PRODUCT_CONTEXT.primaryJtbd as unknown as Prisma.InputJsonValue,
+        currentAlternative: MARIA_PRODUCT_CONTEXT.currentAlternative,
+        doNothingImpact: MARIA_PRODUCT_CONTEXT.doNothingImpact,
+        primaryMetric: MARIA_PRODUCT_CONTEXT.primaryMetric,
+        stage: MARIA_PRODUCT_CONTEXT.stage,
+        strategicBets: MARIA_PRODUCT_CONTEXT.strategicBets as unknown as Prisma.InputJsonValue,
+        openAssumptions: MARIA_PRODUCT_CONTEXT.openAssumptions as unknown as Prisma.InputJsonValue,
+        reviewCadence: MARIA_PRODUCT_CONTEXT.reviewCadence,
+        completedAt: new Date(),
+      },
+      update: {},
+    })
+
+    // ------------------------------------------------------------------------
+    // 4. Project Cafeteria Beta (idempotente via findFirst por [userId, name])
+    // ------------------------------------------------------------------------
+    const foundProject = await findMariaProject(prisma, user.id)
+    created.project = !foundProject
+
+    const projectId = foundProject
+      ? foundProject.id
+      : (
+          await prisma.project.create({
+            data: {
+              userId: user.id,
+              name: MARIA_PROJECT.name,
+              description: MARIA_PROJECT.description,
+              phase: MARIA_PROJECT.phase,
+              stageKey: MARIA_PROJECT.stageKey,
+              version: MARIA_PROJECT.version,
+            },
+            select: { id: true },
+          })
+        ).id
+
+    logger.info(
+      `Project ${MARIA_PROJECT.name}: ${projectId} (${created.project ? 'criado' : 'já existia'}).`,
+    )
+
+    // ------------------------------------------------------------------------
+    // 5. PlanBlocks — 14 blocos APPROVED (upsert via unique composite)
+    // ------------------------------------------------------------------------
+    const approvedAt = new Date()
+    for (const block of MARIA_ALL_BLOCKS) {
+      const existing = await prisma.planBlock.findUnique({
+        where: {
+          projectId_planType_blockId: {
+            projectId,
+            planType: block.planType,
+            blockId: block.blockId,
+          },
+        },
+        select: { id: true },
+      })
+      if (!existing) created.planBlocks++
+
+      await prisma.planBlock.upsert({
+        where: {
+          projectId_planType_blockId: {
+            projectId,
+            planType: block.planType,
+            blockId: block.blockId,
+          },
+        },
+        create: {
+          projectId,
+          planType: block.planType,
+          blockId: block.blockId,
+          order: block.order,
+          title: block.title,
+          body: block.body,
+          status: MARIA_BLOCK_STATUS,
+          approvedAt,
+        },
+        update: {},
+      })
+    }
+
+    // ------------------------------------------------------------------------
+    // 6. DecisionDrafts (pending — 2 sugestões da Inbox)
+    // Idempotente via composição [projectId, title] (nível de aplicação,
+    // schema não exige unique). Evita duplicar em re-runs.
+    // ------------------------------------------------------------------------
+    for (const draft of MARIA_DECISION_DRAFTS) {
+      const existing = await prisma.decisionDraft.findFirst({
+        where: { projectId, title: draft.title },
+        select: { id: true },
+      })
+      if (existing) continue
+
+      await prisma.decisionDraft.create({
+        data: {
+          projectId,
+          title: draft.title,
+          yStatement: draft.yStatement,
+          category: draft.category,
+          origin: draft.origin,
+          trigger: draft.trigger,
+        },
+      })
+      created.decisionDrafts++
+    }
+
+    // ------------------------------------------------------------------------
+    // 7. RiskDrafts (pending — 2 sugestões da Inbox)
+    // ------------------------------------------------------------------------
+    for (const draft of MARIA_RISK_DRAFTS) {
+      const existing = await prisma.riskDraft.findFirst({
+        where: { projectId, title: draft.title },
+        select: { id: true },
+      })
+      if (existing) continue
+
+      await prisma.riskDraft.create({
+        data: {
+          projectId,
+          title: draft.title,
+          description: draft.description,
+          trigger: draft.trigger,
+          category: draft.category,
+          origin: draft.origin,
+        },
+      })
+      created.riskDrafts++
+    }
+
+    logger.info(
+      `Seed Maria concluído: user=${user.id}, project=${projectId}, ` +
+        `planBlocksCriados=${created.planBlocks}/14, ` +
+        `decisionDraftsCriados=${created.decisionDrafts}/2, ` +
+        `riskDraftsCriados=${created.riskDrafts}/2.`,
+    )
+
+    return { userId: user.id, projectId, created }
+  } finally {
+    if (ownsPrisma) {
+      await prisma.$disconnect()
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+// CLI entrypoint
+// ----------------------------------------------------------------------------
+
+const isDirectRun =
+  typeof process !== 'undefined' &&
+  Array.isArray(process.argv) &&
+  process.argv[1] &&
+  import.meta.url === `file://${process.argv[1]}`
+
+if (isDirectRun) {
+  seedMaria()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      consoleLogger.error(
+        `Seed Maria falhou: ${err instanceof Error ? err.message : String(err)}`,
+      )
+      process.exit(1)
+    })
+}

--- a/src/test/fixtures/maria-canonical.ts
+++ b/src/test/fixtures/maria-canonical.ts
@@ -1,0 +1,382 @@
+/**
+ * Fixtures canônicas — Maria Silva / Cafeteria Beta.
+ *
+ * Single source of truth para:
+ * - `prisma/seed-maria.ts` (TRC-14.7) — popula o DB local/dev.
+ * - testes unitários de UI/serviços que precisam de um estado Maria completo.
+ *
+ * Conteúdo espelha `Spec/Jornada Coleta inicial/src/data.jsx` e
+ * `Spec/Jornada Coleta inicial/src/data-risks.jsx` (fonte do produto).
+ * Qualquer mudança aqui deve ser refletida também nos mockups — e vice-versa.
+ *
+ * Regra CLAUDE.md #6: conteúdo em pt-BR acentuado.
+ */
+
+import {
+  AssumptionCategory,
+  BlockStatus,
+  DecisionCategory,
+  PlanType,
+  PlatformTier,
+  ProductStage,
+  ProjectPhase,
+  ReviewCadence,
+  RiskCategory,
+  RiskImpact,
+  RiskProbability,
+} from '@prisma/client'
+
+// ----------------------------------------------------------------------------
+// User + CreditLedger
+// ----------------------------------------------------------------------------
+
+/**
+ * clerkId fixo garante idempotência do seed — re-runs atualizam o mesmo User
+ * em vez de criar duplicatas.
+ */
+export const MARIA_CLERK_ID = 'seed-maria-clerk-id'
+
+export const MARIA_USER = {
+  clerkId: MARIA_CLERK_ID,
+  email: 'maria@cafeteriabeta.example',
+  name: 'Maria Silva',
+  // PersonaTag definido via seed com type-safety; aqui string literal para
+  // manter o arquivo sem imports desnecessários em consumidores de teste.
+} as const
+
+/**
+ * Estado pós-export v1.0: 1 crédito restante (journey consumiu 59 dos 60
+ * disponíveis no trial). Ver CREDIT_STATES.exportar=1 em data.jsx.
+ */
+export const MARIA_CREDIT_LEDGER = {
+  balance: 1,
+  tier: PlatformTier.TRIAL,
+} as const
+
+// ----------------------------------------------------------------------------
+// ProductContext (POLICY-010) — 9 campos da Maria
+// ----------------------------------------------------------------------------
+
+export interface MariaProductContext {
+  userSegment: string
+  primaryJtbd: { situation: string; motivation: string; outcome: string }
+  currentAlternative: string
+  doNothingImpact: string
+  primaryMetric: string
+  stage: ProductStage
+  strategicBets: string[]
+  openAssumptions: Array<{ category: AssumptionCategory; statement: string }>
+  reviewCadence: ReviewCadence
+}
+
+export const MARIA_PRODUCT_CONTEXT: MariaProductContext = {
+  userSegment:
+    'Dona de cafeteria de bairro em Campinas com ~180 clientes recorrentes (25-45 anos, 90%+ usa Pix diariamente). Moram ou trabalham a até 600m do ponto.',
+  primaryJtbd: {
+    situation: 'Quando estou no rush do almoço (11h40-13h30) com o balcão cheio e WhatsApp acumulando',
+    motivation: 'preciso parar de perder pedidos de clientes fiéis que desistem por falta de resposta',
+    outcome:
+      'que o cliente consiga fazer o pedido de retirada, pagar antecipado via Pix e escolher horário, sem depender de eu responder mensagem.',
+  },
+  currentAlternative:
+    'WhatsApp Business manual + atendimento presencial no balcão. Tentativa anterior de resposta automática foi rejeitada pelos clientes.',
+  doNothingImpact:
+    'Perde 15 a 20 pedidos por semana (ticket médio R$ 28) — estimados R$ 1.800 a R$ 2.240 por mês não capturados.',
+  primaryMetric: 'Pedidos por semana capturados fora do balcão',
+  stage: ProductStage.PRE_PRODUCT,
+  strategicBets: [
+    'Estamos apostando que pagamento antecipado via Pix + horário fixo de retirada destravam o rush sem intervenção humana.',
+    'Estamos apostando que os clientes fiéis do bairro preferem Pix sem taxa a iFood com comissão.',
+    'Estamos apostando que manter a relação direta (sem intermediário) sustenta o posicionamento de cafeteria de bairro.',
+  ],
+  openAssumptions: [
+    {
+      category: AssumptionCategory.USER,
+      statement: 'Clientes fiéis abrem o link do WhatsApp sem fricção e completam o pedido no mobile.',
+    },
+    {
+      category: AssumptionCategory.PROBLEM,
+      statement:
+        'O abandono é por falta de resposta rápida (fila na confirmação), não por preço nem por oferta concorrente.',
+    },
+    {
+      category: AssumptionCategory.SOLUTION,
+      statement:
+        'Código de retirada de 3 dígitos é suficiente para identificar o pedido no balcão sem cadastro do cliente.',
+    },
+    {
+      category: AssumptionCategory.ADOPTION,
+      statement: 'Primeira indicação boca-a-boca converte em < 30 segundos, sem login obrigatório.',
+    },
+  ],
+  reviewCadence: ReviewCadence.QUARTERLY,
+}
+
+// ----------------------------------------------------------------------------
+// Project Cafeteria Beta (estado pós-export v1.0)
+// ----------------------------------------------------------------------------
+
+export const MARIA_PROJECT = {
+  name: 'Cafeteria Beta Pedidos',
+  description:
+    'Mini-app web de pedidos de retirada com pagamento Pix antecipado para a Cafeteria Beta (Campinas).',
+  phase: ProjectPhase.ESPECIFICACAO,
+  stageKey: 'exportar',
+  version: 'v1.0',
+} as const
+
+// ----------------------------------------------------------------------------
+// Discovery Questions (5 perguntas + respostas canônicas)
+// Reproduz DISCOVERY_QUESTIONS de Spec/.../data.jsx literalmente.
+// ----------------------------------------------------------------------------
+
+export interface MariaDiscoveryQuestion {
+  n: number
+  prompt: string
+  replies: string[]
+  answer: string
+}
+
+export const MARIA_DISCOVERY_QUESTIONS: MariaDiscoveryQuestion[] = [
+  {
+    n: 1,
+    prompt: 'Oi, Maria. Bora tirar essa ideia da cabeça. Me conta: o que você gostaria de criar?',
+    replies: ['📱 App de gestão', '🛒 E-commerce', '📊 Dashboard', '🎨 Portfólio'],
+    answer:
+      'Tenho uma cafeteria de bairro em Campinas, a Cafeteria Beta. No rush do almoço eu perco 15 a 20 pedidos por semana porque não consigo responder o WhatsApp. Queria um mini-app onde o cliente faz o pedido de retirada, escolhe o horário e paga antecipado via Pix — sem depender de eu responder mensagem.',
+  },
+  {
+    n: 2,
+    prompt: 'E quem sente essa dor hoje? Fala um pouco do perfil de quem você quer atender.',
+    replies: ['👥 Pequenas empresas', '🎯 Freelancers', '🏢 Times remotos', '🛍️ Lojistas'],
+    answer:
+      'São meus clientes fiéis — gente que passa na cafeteria entre 12h e 13h pra retirar, mora ou trabalha perto. De 25 a 45 anos, já usa Pix todo dia. Tenho uns 180 clientes recorrentes.',
+  },
+  {
+    n: 3,
+    prompt:
+      'Legal. Agora me diz: o que esse app precisa fazer no primeiro dia pra valer a pena pra quem usa?',
+    replies: ['🔐 Login/cadastro', '📊 Dashboard', '📝 CRUD completo', '🔔 Notificações'],
+    answer:
+      'Ver o cardápio do dia com foto e preço, montar o pedido, pagar no Pix e escolher horário de retirada em janelas de 15 minutos nas próximas 3 horas.',
+  },
+  {
+    n: 4,
+    prompt: 'O que faz seu app ser melhor do que a pessoa já resolvendo isso de outro jeito?',
+    replies: ['🎨 Mais simples', '💰 Preço melhor', '⚡ Mais rápido', '🎯 Mais focado'],
+    answer:
+      'Comparado ao WhatsApp: o cliente paga antes e escolhe horário fixo, sem ficar perguntando "tá pronto?". Comparado ao iFood: não cobro taxa e mantenho a relação direta com o cliente do bairro.',
+  },
+  {
+    n: 5,
+    prompt: 'Último ponto: como isso se paga?',
+    replies: ['💳 Freemium', '📅 Assinatura mensal', '🎁 100% gratuito', '💼 Por usuário'],
+    answer:
+      'Grátis pra quem pede. Meu ganho vem das vendas que hoje escapam — estimo uns R$ 1.800 a 2.200 por mês a mais. Não quero cobrar taxa do cliente.',
+  },
+]
+
+// ----------------------------------------------------------------------------
+// PlanBlocks — 6 NEGOCIO + 4 UX + 4 TECNICO = 14 blocos, todos APPROVED
+// Bodies mantidos fiéis a BUSINESS_BLOCKS / UX_BLOCKS / TECH_BLOCKS do mockup.
+// ----------------------------------------------------------------------------
+
+export interface MariaPlanBlock {
+  planType: PlanType
+  blockId: string
+  order: number
+  title: string
+  body: string
+}
+
+export const MARIA_BUSINESS_BLOCKS: MariaPlanBlock[] = [
+  {
+    planType: PlanType.NEGOCIO,
+    blockId: 'visao',
+    order: 1,
+    title: 'Visão geral',
+    body: 'Mini-app web de pedidos de retirada para a Cafeteria Beta, cafeteria de bairro em Campinas com 2 anos de operação e cerca de 180 clientes recorrentes. A proposta se chama **Cafeteria Beta Pedidos** com a tagline **"Receba pedidos sem parar de atender o balcão"**.\n\nO escopo é enxuto por decisão: não há entrega, não há cadastro obrigatório, não há fidelidade. Quem pediu, pagou, pegou no horário escolhido. Expansões (encomenda com 48h, cupom via Instagram) ficam para iterações futuras.',
+  },
+  {
+    planType: PlanType.NEGOCIO,
+    blockId: 'problema',
+    order: 2,
+    title: 'Problema',
+    body: 'Entre 11h40 e 13h30 o WhatsApp Business acumula mensagens que ninguém tem mão pra ler. Cliente fiel manda "boto o mesmo de ontem?" e, sem resposta, desiste. Maria estima perder **15 a 20 pedidos por semana** (ticket médio R$ 28 → R$ 1.800 a R$ 2.240/mês não capturados).\n\nTentativa anterior com resposta automática foi rejeitada pelos clientes — o problema não é resposta automática, é ter um **canal paralelo** que funciona sem depender da barista estar livre.',
+  },
+  {
+    planType: PlanType.NEGOCIO,
+    blockId: 'publico',
+    order: 3,
+    title: 'Público-alvo',
+    body: '**Primário**: base atual de 180 clientes recorrentes — 25 a 45 anos, moram ou trabalham até 600m da cafeteria, passam entre 12h e 13h para retirar. 90%+ usa Pix diariamente.\n\n**Secundário**: "amigo do cliente fiel", que recebe indicação e decide experimentar — razão para manter o fluxo sem login obrigatório.',
+  },
+  {
+    planType: PlanType.NEGOCIO,
+    blockId: 'features',
+    order: 4,
+    title: 'Features core',
+    body: '1. Cardápio digital com categorias (café, salgado, doce, combos), foto e preço atualizados por Maria 1×/dia\n2. Carrinho simples com soma automática e observações por item\n3. Pagamento Pix via Mercado Pago (QR code + copia-e-cola)\n4. Seleção de horário de retirada em janelas de 15 min dentro das próximas 3h\n5. Tela de confirmação com código de 3 dígitos para apresentar no balcão\n6. Painel simples para Maria ver pedidos do dia e marcar como pronto',
+  },
+  {
+    planType: PlanType.NEGOCIO,
+    blockId: 'diferenciais',
+    order: 5,
+    title: 'Diferenciais',
+    body: 'Comparado ao WhatsApp: cliente paga antes (barista não precisa interromper atendimento presencial) e escolhe horário fixo (elimina o "tá pronto?" repetido).\n\nComparado ao iFood: sem taxa e com relação direta preservada — combina com o posicionamento de cafeteria de bairro.',
+  },
+  {
+    planType: PlanType.NEGOCIO,
+    blockId: 'monetizacao',
+    order: 6,
+    title: 'Monetização',
+    body: 'Zero cobrança do cliente final. O ganho vem do aumento de pedidos capturados que hoje escapam.\n\nInfra estimada: Vercel free + Supabase free + Mercado Pago (0,99% por transação) ≈ R$ 40/mês de custo fixo.',
+  },
+]
+
+export const MARIA_UX_BLOCKS: MariaPlanBlock[] = [
+  {
+    planType: PlanType.UX,
+    blockId: 'personas',
+    order: 1,
+    title: 'Personas',
+    body: '**João, cliente fiel** (30 anos, comercial de vendas perto da cafeteria, gasta R$ 32 em média, usa 3×/semana, Pix salvo no celular).\n\n**Ana, cliente de indicação** (28, primeira visita, precisa decidir se confia em 30 segundos — mantém o fluxo sem login obrigatório).\n\n**Maria, dona** (painel separado, login Google, vê pedidos pagos do dia ordenados por horário de retirada).',
+  },
+  {
+    planType: PlanType.UX,
+    blockId: 'jornadas',
+    order: 2,
+    title: 'Jornadas',
+    body: '**Jornada crítica (João)**: recebe link via WhatsApp → abre no celular → cardápio do dia → escolhe 2 itens → total → Pagar com Pix → QR/copia-e-cola → paga → volta ao app → confirmação com código 427 para 12h15.\n\n**Jornada secundária (Ana)**: antes do cardápio vê tela opcional "Cafeteria Beta, desde 2024 no bairro Cambuí" com foto da fachada (skip em 1 toque).',
+  },
+  {
+    planType: PlanType.UX,
+    blockId: 'telas',
+    order: 3,
+    title: 'Telas principais',
+    body: '**Cliente (6 telas)**: Cardápio · Item detalhe · Carrinho · Pagamento Pix · Confirmação · Pedido pendente (acesso por link).\n\n**Maria (2 telas)**: Painel de pedidos do dia (lista ordenada por horário com chip de status) · Editor de cardápio (toggle de disponibilidade, preço inline).',
+  },
+  {
+    planType: PlanType.UX,
+    blockId: 'tokens',
+    order: 4,
+    title: 'Design tokens',
+    body: 'Cor primária **âmbar `#f59e0b`** (herdada do avatar do projeto), neutros cinza-50 a cinza-900, tipografia system fonts, raio 12px em cards (mais acolhedor), sombra suave em cards interativos.\n\nFeedback: verde sucesso, amarelo atenção, vermelho erro. Tokens exportados como JSON para alimentar Tailwind config.',
+  },
+]
+
+export const MARIA_TECH_BLOCKS: MariaPlanBlock[] = [
+  {
+    planType: PlanType.TECNICO,
+    blockId: 'stack',
+    order: 1,
+    title: 'Stack',
+    body: '**Next.js 15** (App Router) + TypeScript · **Prisma** ORM sobre **Postgres** no Supabase (free tier) · **Tailwind** seguindo tokens de UX · **Mercado Pago SDK Node** para Pix.\n\nHospedagem: Vercel free tier (cobre 400–1.500 pedidos/mês estimados). Sem backend separado — APIs em route handlers do Next.',
+  },
+  {
+    planType: PlanType.TECNICO,
+    blockId: 'arquitetura',
+    order: 2,
+    title: 'Arquitetura',
+    body: 'Monolito simples, deploy único. Frontend público (cardápio + pedido) e painel da Maria coexistem no mesmo app. Auth da Maria via **Clerk** (Google SSO). Clientes finais não autenticam — identificação por código de retirada + telefone opcional.\n\nFluxo crítico: cliente confirma → API cria Order(Pending) → MP gera cobrança → webhook confirma → status Paid → painel via SSE.',
+  },
+  {
+    planType: PlanType.TECNICO,
+    blockId: 'dados',
+    order: 3,
+    title: 'Modelo de dados',
+    body: 'Entidades: `Store` (modelada multi-tenant), `MenuItem` (nome, descrição, preço, foto, categoria, disponível), `Order` (status, total, horário retirada, código 3 dígitos, pix_id), `OrderItem` (quantidade, observação), `OperatingHour` (dia, abre, fecha).\n\nCardápio do dia = `MenuItem.disponivel = true` + regras de horário opcionais.',
+  },
+  {
+    planType: PlanType.TECNICO,
+    blockId: 'integracoes',
+    order: 4,
+    title: 'Integrações',
+    body: '**Mercado Pago** via SDK oficial Node, chave secreta em env Vercel, webhook `/api/mp/webhook` validando assinatura.\n\nNenhuma integração com iFood, Rappi ou WhatsApp no MVP — decisão explícita da Maria para manter foco (registrada no Decision Log).',
+  },
+]
+
+/** Total canônico: 14 blocos (6 NEGOCIO + 4 UX + 4 TECNICO), todos APPROVED no estado exportado. */
+export const MARIA_ALL_BLOCKS: MariaPlanBlock[] = [
+  ...MARIA_BUSINESS_BLOCKS,
+  ...MARIA_UX_BLOCKS,
+  ...MARIA_TECH_BLOCKS,
+]
+
+export const MARIA_BLOCK_STATUS: BlockStatus = BlockStatus.APPROVED
+
+// ----------------------------------------------------------------------------
+// Decision Drafts (pending, aguardam triagem na Inbox)
+// ----------------------------------------------------------------------------
+
+export interface MariaDecisionDraft {
+  proposedPublicId: string
+  title: string
+  yStatement: string
+  category: DecisionCategory
+  origin: string
+  trigger: string
+}
+
+export const MARIA_DECISION_DRAFTS: MariaDecisionDraft[] = [
+  {
+    proposedPublicId: 'CB-DEC-001',
+    title: 'Não competir com delivery; foco em pedido agendado',
+    yStatement:
+      'No contexto do lançamento da **Cafeteria Beta Pedidos**, vendo que o problema central é captura de pedidos no rush (não logística de entrega), decidimos **não implementar delivery próprio nem integração com iFood/Rappi** no MVP, para alcançar **foco no fluxo de retirada agendada com pagamento antecipado**, aceitando que **pedidos fora da área de retirada ficam de fora e que parte da base de clientes pode querer entrega** (reavaliar em 6 meses com dados de demanda real).',
+    category: DecisionCategory.PRODUTO,
+    origin: 'Plano de Negócio · Visão geral',
+    trigger: 'Sugerido porque você escreveu: "sem parar de atender o balcão" e "escolhe o horário de retirada".',
+  },
+  {
+    proposedPublicId: 'CB-DEC-002',
+    title: 'Sem cadastro obrigatório para cliente final',
+    yStatement:
+      'No contexto da jornada de pedido para **amigo do cliente fiel** que recebe indicação, vendo que a primeira visita precisa converter em < 30 segundos, decidimos **não exigir login nem cadastro do cliente final**, para alcançar **fricção mínima na primeira compra**, aceitando **perda de dados de perfil** e **reuso entre pedidos só via telefone opcional no carrinho**.',
+    category: DecisionCategory.PRODUTO,
+    origin: 'Plano de UX · Personas',
+    trigger: 'Sugerido porque você escreveu: "mantenho a relação direta com o cliente do bairro".',
+  },
+]
+
+// ----------------------------------------------------------------------------
+// Risk Drafts (pending, aguardam triagem na Inbox)
+// ----------------------------------------------------------------------------
+
+export interface MariaRiskDraft {
+  proposedPublicId: string
+  title: string
+  description: string
+  trigger: string
+  category: RiskCategory
+  impact: RiskImpact
+  probability: RiskProbability
+  origin: string
+}
+
+export const MARIA_RISK_DRAFTS: MariaRiskDraft[] = [
+  {
+    proposedPublicId: 'CB-RISK-001',
+    title: 'Falha de confirmação Pix pode travar a fila de retirada',
+    description:
+      'Se o webhook do Mercado Pago atrasar ou falhar durante o rush do almoço (12h-13h), pedidos pagos não aparecem no painel da Maria — cliente pagou e não tem como retirar, e ela não tem como validar manualmente sem interromper o balcão.',
+    trigger:
+      'Webhook do MP atrasar > 30s · resposta 4xx/5xx do endpoint /api/mp/webhook · diferença entre pedidos no painel e extrato MP do dia.',
+    category: RiskCategory.TECNICO,
+    impact: RiskImpact.ALTO,
+    probability: RiskProbability.MEDIA,
+    origin: 'Plano Técnico · Integrações',
+  },
+  {
+    proposedPublicId: 'CB-RISK-002',
+    title: 'Cardápio desatualizado gera pedidos de itens indisponíveis',
+    description:
+      'Se a Maria esquecer de atualizar a disponibilidade dos itens no dia (principalmente salgados, que acabam no meio da tarde), clientes vão pedir e pagar por itens que já não existem — gera refund e quebra a confiança na operação.',
+    trigger:
+      'Pedido pago para item marcado como "disponível" mas já esgotado no balcão · reclamação do cliente chegando por WhatsApp após pagar.',
+    category: RiskCategory.MERCADO,
+    impact: RiskImpact.MEDIO,
+    probability: RiskProbability.ALTA,
+    origin: 'Plano de UX · Telas principais',
+  },
+]

--- a/src/test/fixtures/maria-canonical.ts
+++ b/src/test/fixtures/maria-canonical.ts
@@ -374,7 +374,10 @@ export const MARIA_RISK_DRAFTS: MariaRiskDraft[] = [
       'Se a Maria esquecer de atualizar a disponibilidade dos itens no dia (principalmente salgados, que acabam no meio da tarde), clientes vão pedir e pagar por itens que já não existem — gera refund e quebra a confiança na operação.',
     trigger:
       'Pedido pago para item marcado como "disponível" mas já esgotado no balcão · reclamação do cliente chegando por WhatsApp após pagar.',
-    category: RiskCategory.MERCADO,
+    // REPUTACAO: o vetor primário é dano de confiança do cliente (quem paga e
+    // não recebe), não disputa de mercado. Mockup original usava 'Operacional'
+    // (inexistente no enum). Suggestion Code-Reviewer TRC-14.7.
+    category: RiskCategory.REPUTACAO,
     impact: RiskImpact.MEDIO,
     probability: RiskProbability.ALTA,
     origin: 'Plano de UX · Telas principais',


### PR DESCRIPTION
## Summary

Seed idempotente da Maria (projeto pós-export v1.0) + fixtures reutilizáveis em testes unitários. Content copiado fiel de `Spec/Jornada Coleta inicial/src/data.jsx` e `data-risks.jsx`.

7ª sub-task do TRC-14 Fundação.

Notion: [TRC-14.7](https://www.notion.so/34b0d9578db3818ab8ace7e18615017b) · [TRC-14 épico](https://www.notion.so/34b0d9578db3813e860ecacb4a83055e)

## Conteúdo canônico criado

- User Maria Silva (`clerkId=seed-maria-clerk-id`, personaTag=FOUNDER, solo)
- ProductContext com 9 campos POLICY-010 (JTBD tríade, 2 bets, 3 assumptions)
- Project Cafeteria Beta (phase=ESPECIFICACAO, stageKey=exportar, version=v1.0)
- 14 PlanBlocks (6 Negócio + 4 UX + 4 Técnico) todos APPROVED
- 2 DecisionDrafts (CB-DEC-001 não competir com delivery; CB-DEC-002 sem cadastro)
- 2 RiskDrafts (CB-RISK-001 falha Pix; CB-RISK-002 cardápio desatualizado)
- CreditLedger balance=1 (pós-export)

## Arquivos

- `src/test/fixtures/maria-canonical.ts` — single source of truth (seed + tests importam daqui)
- `prisma/seed-maria.ts` — orquestrador + CLI (`npm run db:seed:maria`)
- `prisma/seed-maria.test.ts` — 4 cenários integração (skipam se DB off)
- `docs/seeds/maria.md` — runbook + reset via DELETE CASCADE
- `package.json` — script npm

## Decisões notáveis

- Idempotência de drafts via `findFirst({projectId, title})` em app-level (schema não tem unique em DecisionDraft/RiskDraft).
- Mockup "Pagamentos" → `RiskCategory.TECNICO`; "Operacional" → `MERCADO` — documentado em `docs/seeds/maria.md`.
- `publicId` "CB-DEC-001" fica como `proposedPublicId` em fixture (schema só tem `publicId` em registrados, não drafts).
- `DISCOVERY_QUESTIONS` exportadas mas não persistidas (schema não modela mensagens de Discovery ainda; fixture serve UI tests).

## Test plan

- [x] `npx prisma validate` OK
- [x] `npm run lint` limpo
- [x] `npm run build` passa
- [x] `npm test` — 587/587 (4 novos)
- [x] `npm run db:seed:maria` — criou estado completo (14 blocos + 4 drafts + ledger)
- [x] `npm run db:seed:maria` 2ª vez — 0 duplicações, idempotente
- [ ] Rodar em dev + abrir dashboard pra conferir visualmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)