### PR TITLE
chore(shell): cleanup pós-refactor (TRC-14.9)

### DIFF
--- a/src/app/design-system/shell-showcase.tsx
+++ b/src/app/design-system/shell-showcase.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import Link from 'next/link'
 
 import { CreditsChip } from '@/components/shell/CreditsChip'
-import { Sidebar } from '@/components/shell/Sidebar'
+import { ProductSidebar } from '@/components/shell/ProductSidebar'
 import { TierBadge, type PlatformTier } from '@/components/shell/TierBadge'
 import { UserChip } from '@/components/shell/UserChip'
 import { Callout } from '@/components/ui/callout'
@@ -47,8 +47,7 @@ export function ShellShowcase() {
           CreditsChip
         </h3>
         <p className="mt-1 text-xs text-ink-tertiary">
-          Cor varia por faixa: neutral (&gt;40), warning (10–40), error
-          (&lt;10).
+          Cor varia por faixa: neutral (≥13), warning (7–12), error (&lt;7).
         </p>
         <div className="mt-3 flex flex-wrap items-center gap-3 rounded-brand-lg border border-line bg-surface p-4">
           <CreditsChip balance={60} />
@@ -99,8 +98,9 @@ export function ShellShowcase() {
         </h3>
         <p className="mt-1 text-xs text-ink-tertiary">
           Overlay exibido em viewports abaixo de {APP_MIN_WIDTH_PX}px dentro do
-          app autenticado (ADR-016 / TRC-14.8). Preview inline abaixo — em
-          produção o container é <code>fixed inset-0</code>.
+          app autenticado (desktop-first; ver TRC-14 / Decision Log no Notion).
+          Preview inline abaixo — em produção o container é{' '}
+          <code>fixed inset-0</code>.
         </p>
         <ViewportGatePreview />
       </div>
@@ -183,11 +183,11 @@ function SidebarPreview({ tier }: { tier: PlatformTier }) {
   )
 }
 
-/** Variante da Sidebar confinada ao preview (não `fixed` global). */
+/** Variante da ProductSidebar confinada ao preview (não `fixed` global). */
 function ScopedSidebar({ tier }: { tier: PlatformTier }) {
   return (
     <div className="absolute inset-y-0 left-0">
-      <Sidebar
+      <ProductSidebar
         userName="Maria Silva"
         tier={tier}
         credits={tier === 'TRIAL' ? 60 : 40}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en">
+    <html lang="pt-BR">
       <body className="antialiased" suppressHydrationWarning>
         <Providers>
           <ClerkWrapper>

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -18,7 +18,6 @@ import { AppShellClient } from './AppShellClient'
 
 type ShellData = {
   userName: string
-  userInitial: string | undefined
   tier: PlatformTier
   credits: number
 }
@@ -26,7 +25,6 @@ type ShellData = {
 async function loadShellData(): Promise<ShellData> {
   const fallback: ShellData = {
     userName: 'Você',
-    userInitial: undefined,
     tier: 'TRIAL',
     credits: 0,
   }
@@ -60,7 +58,6 @@ async function loadShellData(): Promise<ShellData> {
 
     return {
       userName: name ?? fallback.userName,
-      userInitial: undefined,
       tier: (user?.creditLedger?.tier ?? 'TRIAL') as PlatformTier,
       credits: user?.creditLedger?.balance ?? 0,
     }
@@ -78,7 +75,6 @@ export async function AppShell({ children }: { children: ReactNode }) {
   return (
     <AppShellClient
       userName={data.userName}
-      userInitial={data.userInitial}
       tier={data.tier}
       credits={data.credits}
     >

--- a/src/components/shell/AppShellClient.tsx
+++ b/src/components/shell/AppShellClient.tsx
@@ -3,7 +3,9 @@
 import * as React from 'react'
 import { usePathname } from 'next/navigation'
 
-import { Sidebar } from './Sidebar'
+import { PUBLIC_ROUTE_PREFIXES } from '@/lib/routes'
+
+import { ProductSidebar } from './ProductSidebar'
 import type { PlatformTier } from './TierBadge'
 import { ViewportGate } from './ViewportGate'
 
@@ -11,25 +13,21 @@ import { ViewportGate } from './ViewportGate'
  * TRC-14.4 — Wrapper client que decide se a sidebar global deve ser renderizada.
  *
  * Rotas públicas (home, sign-in/up, design-system) herdam o mesmo RootLayout
- * mas NÃO devem receber o shell. Mantemos essa lista sincronizada com o
- * `createRouteMatcher` de `src/middleware.ts` (tb alvo de checagem no review).
+ * mas NÃO devem receber o shell. A lista vem de `src/lib/routes.ts`
+ * (TRC-14.9), mesma fonte usada pelo Clerk middleware pra evitar divergência
+ * entre "rota pública" e "rota sem shell".
  */
-
-const PUBLIC_PREFIXES = [
-  '/sign-in',
-  '/sign-up',
-  '/design-system',
-]
 
 function isPublicPath(pathname: string | null): boolean {
   if (!pathname) return true
   if (pathname === '/') return true
-  return PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+  return PUBLIC_ROUTE_PREFIXES.some(
+    (prefix) => prefix !== '/' && pathname.startsWith(prefix),
+  )
 }
 
 type AppShellClientProps = {
   userName: string
-  userInitial?: string
   tier: PlatformTier
   credits: number
   /** Contadores reais viram props reais em TRC-19; default 0 no MVP. */
@@ -41,7 +39,6 @@ type AppShellClientProps = {
 
 export function AppShellClient({
   userName,
-  userInitial,
   tier,
   credits,
   inboxCount = 0,
@@ -57,17 +54,17 @@ export function AppShellClient({
 
   return (
     <div className="min-h-screen bg-surface-canvas">
-      <Sidebar
+      <ProductSidebar
         userName={userName}
-        userInitial={userInitial}
         tier={tier}
         credits={credits}
         inboxCount={inboxCount}
         riskCount={riskCount}
         decisionCount={decisionCount}
       />
-      {/* TRC-14.8 — gate desktop-first (ADR-016). Só renderiza em <1280px e
-       * apenas dentro do shell autenticado (rotas públicas saíram acima). */}
+      {/* TRC-14.8 — gate desktop-first (ver Decision Log no Notion). Só
+       * renderiza em <1280px e apenas dentro do shell autenticado (rotas
+       * públicas saíram acima). */}
       <ViewportGate />
       {/* Sidebar flutua (fixed) e ocupa 56px base; expande em hover por cima.
        * Mantemos `pl-14` fixo para que o conteúdo nunca se desloque. */}

--- a/src/components/shell/ProductSidebar.test.tsx
+++ b/src/components/shell/ProductSidebar.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 
-import { Sidebar } from './Sidebar'
+import { ProductSidebar } from './ProductSidebar'
 
 const pathnameMock = vi.fn<[], string>(() => '/dashboard')
 
@@ -9,7 +9,7 @@ vi.mock('next/navigation', () => ({
   usePathname: () => pathnameMock(),
 }))
 
-describe('Sidebar', () => {
+describe('ProductSidebar', () => {
   beforeEach(() => {
     pathnameMock.mockReset()
     pathnameMock.mockReturnValue('/dashboard')
@@ -17,7 +17,7 @@ describe('Sidebar', () => {
 
   it('renderiza por padrão em modo colapsado (data-expanded="false")', () => {
     render(
-      <Sidebar userName="Maria Silva" tier="TRIAL" credits={60} />,
+      <ProductSidebar userName="Maria Silva" tier="TRIAL" credits={60} />,
     )
     const aside = screen.getByTestId('app-sidebar')
     expect(aside).toHaveAttribute('data-expanded', 'false')
@@ -28,7 +28,7 @@ describe('Sidebar', () => {
 
   it('expande em hover (mouseEnter troca data-expanded para true)', () => {
     render(
-      <Sidebar userName="Maria Silva" tier="TRIAL" credits={60} />,
+      <ProductSidebar userName="Maria Silva" tier="TRIAL" credits={60} />,
     )
     const aside = screen.getByTestId('app-sidebar')
     fireEvent.mouseEnter(aside)
@@ -41,7 +41,7 @@ describe('Sidebar', () => {
   it('mostra apenas "Projetos" em rotas fora de /project', () => {
     pathnameMock.mockReturnValue('/dashboard')
     render(
-      <Sidebar userName="Maria" tier="TRIAL" credits={60} />,
+      <ProductSidebar userName="Maria" tier="TRIAL" credits={60} />,
     )
     const aside = screen.getByTestId('app-sidebar')
     fireEvent.mouseEnter(aside)
@@ -55,7 +55,7 @@ describe('Sidebar', () => {
   it('adiciona itens contextuais em rotas /project/:id', () => {
     pathnameMock.mockReturnValue('/project/abc123')
     render(
-      <Sidebar userName="Maria" tier="PRO" credits={60} />,
+      <ProductSidebar userName="Maria" tier="PRO" credits={60} />,
     )
     const aside = screen.getByTestId('app-sidebar')
     fireEvent.mouseEnter(aside)
@@ -68,7 +68,7 @@ describe('Sidebar', () => {
   it('renderiza active indicator no item cuja rota bate com pathname', () => {
     pathnameMock.mockReturnValue('/project/abc123/riscos')
     render(
-      <Sidebar userName="Maria" tier="PRO" credits={60} riskCount={2} />,
+      <ProductSidebar userName="Maria" tier="PRO" credits={60} riskCount={2} />,
     )
     const aside = screen.getByTestId('app-sidebar')
     fireEvent.mouseEnter(aside)
@@ -88,7 +88,7 @@ describe('Sidebar', () => {
   it('exibe badge numérico destacado quando inboxCount > 0', () => {
     pathnameMock.mockReturnValue('/project/abc123')
     render(
-      <Sidebar userName="Maria" tier="PRO" credits={60} inboxCount={3} />,
+      <ProductSidebar userName="Maria" tier="PRO" credits={60} inboxCount={3} />,
     )
     const aside = screen.getByTestId('app-sidebar')
     fireEvent.mouseEnter(aside)
@@ -102,7 +102,7 @@ describe('Sidebar', () => {
   it('não renderiza badge numérico quando o contador é zero', () => {
     pathnameMock.mockReturnValue('/project/abc123')
     render(
-      <Sidebar userName="Maria" tier="PRO" credits={60} riskCount={0} />,
+      <ProductSidebar userName="Maria" tier="PRO" credits={60} riskCount={0} />,
     )
     const aside = screen.getByTestId('app-sidebar')
     fireEvent.mouseEnter(aside)
@@ -110,7 +110,7 @@ describe('Sidebar', () => {
   })
 
   it('expõe nav wrapper com aria-label principal de navegação', () => {
-    render(<Sidebar userName="Maria" tier="TRIAL" credits={60} />)
+    render(<ProductSidebar userName="Maria" tier="TRIAL" credits={60} />)
     const nav = screen.getByLabelText('Navegação principal')
     expect(nav).toBeInTheDocument()
   })

--- a/src/components/shell/ProductSidebar.tsx
+++ b/src/components/shell/ProductSidebar.tsx
@@ -12,7 +12,9 @@ import { TierBadge, type PlatformTier } from './TierBadge'
 import { UserChip } from './UserChip'
 
 /**
- * TRC-14.4 — Sidebar global 56/224px (modelo Linear/Notion).
+ * TRC-14.4 / TRC-14.9 — ProductSidebar: nav global de produto 56/224px
+ * (modelo Linear/Notion). Nome explícito pra deixar claro que é a nav do app
+ * autenticado — não uma primitiva genérica de UI.
  *
  * Espelha 1:1 `Spec/Jornada Coleta inicial/src/sidebar.jsx`:
  *   - 56px colapsada (default), 224px expandida no hover (200ms ease).
@@ -22,13 +24,12 @@ import { UserChip } from './UserChip'
  *   - Footer com CreditsChip + UserChip.
  *   - Active indicator: barra vertical 3px brand-primary à esquerda do item.
  *
- * A Sidebar flutua sobre o conteúdo: quando expande, cobre temporariamente sem
- * empurrar o `<main>` (AppShell mantém `ml-14` fixo).
+ * Flutua sobre o conteúdo: quando expande, cobre temporariamente sem empurrar
+ * o `<main>` (AppShellClient mantém `pl-14` fixo).
  */
 
-export type SidebarProps = {
+export type ProductSidebarProps = {
   userName: string
-  userInitial?: string
   tier: PlatformTier
   credits: number
   inboxCount?: number
@@ -153,16 +154,15 @@ function isItemActive(item: NavItem, pathname: string | null): boolean {
   return pathname === item.href || pathname.startsWith(`${item.href}/`)
 }
 
-export function Sidebar({
+export function ProductSidebar({
   userName,
-  userInitial,
   tier,
   credits,
   inboxCount = 0,
   riskCount = 0,
   decisionCount = 0,
   className,
-}: SidebarProps) {
+}: ProductSidebarProps) {
   const pathname = usePathname()
   const [hover, setHover] = React.useState(false)
 
@@ -254,7 +254,6 @@ export function Sidebar({
         </div>
         <UserChip
           name={userName}
-          initial={userInitial}
           tier={tier}
           compact={!expanded}
         />

--- a/src/components/shell/UserChip.test.tsx
+++ b/src/components/shell/UserChip.test.tsx
@@ -18,9 +18,8 @@ describe('UserChip', () => {
     expect(screen.queryByText('Free · Pro')).not.toBeInTheDocument()
   })
 
-  it('usa a prop `initial` quando fornecida em vez da primeira letra do nome', () => {
-    render(<UserChip name="renato natali" initial="RN" tier="START" />)
-    // Avatar exibe apenas primeiro caractere de initial, uppercase.
+  it('deriva a inicial do nome (uppercase) mesmo quando escrito em minúsculas', () => {
+    render(<UserChip name="renato natali" tier="START" />)
     expect(screen.getByText('R')).toBeInTheDocument()
   })
 

--- a/src/components/shell/UserChip.tsx
+++ b/src/components/shell/UserChip.tsx
@@ -14,28 +14,24 @@ import { tierLabel, type PlatformTier } from './TierBadge'
 
 export type UserChipProps = {
   name: string
-  /** Inicial exibida no avatar; default é o primeiro caractere de `name`. */
-  initial?: string
   tier: PlatformTier
   /** Modo colapsado: só o avatar. */
   compact?: boolean
   className?: string
 }
 
-function resolveInitial(name: string, initial?: string): string {
-  if (initial && initial.trim()) return initial.trim().charAt(0).toUpperCase()
+function resolveInitial(name: string): string {
   const trimmed = name.trim()
   return trimmed ? trimmed.charAt(0).toUpperCase() : '?'
 }
 
 export function UserChip({
   name,
-  initial,
   tier,
   compact = false,
   className,
 }: UserChipProps) {
-  const avatarInitial = resolveInitial(name, initial)
+  const avatarInitial = resolveInitial(name)
   const planLabel = `Free · ${tierLabel(tier)}`
 
   return (

--- a/src/components/shell/ViewportGate.tsx
+++ b/src/components/shell/ViewportGate.tsx
@@ -8,11 +8,11 @@ import { APP_MIN_WIDTH_PX, useViewport } from '@/hooks/use-viewport'
 /**
  * TRC-14.8 — Gate visual para viewports abaixo de {@link APP_MIN_WIDTH_PX}.
  *
- * Segue a ADR-016 (desktop-first app ≥ 1280px). Renderiza um overlay com
- * `role="dialog"` cobrindo as rotas autenticadas quando o usuário abre o app
- * numa tela pequena. O `AppShellClient` já filtra rotas públicas, então este
- * componente só aparece dentro do shell — landing/sign-in/design-system ficam
- * de fora por construção.
+ * Segue decisão de desktop-first (≥ 1280px, ver Decision Log no Notion).
+ * Renderiza um overlay com `role="dialog"` cobrindo as rotas autenticadas
+ * quando o usuário abre o app numa tela pequena. O `AppShellClient` já filtra
+ * rotas públicas, então este componente só aparece dentro do shell —
+ * landing/sign-in/design-system ficam de fora por construção.
  *
  * Decisão client-side (SSR não sabe a largura do cliente). O primeiro render
  * devolve `null` para evitar flash antes da primeira medição.

--- a/src/components/shell/index.ts
+++ b/src/components/shell/index.ts
@@ -4,8 +4,8 @@
 
 export { AppShell } from './AppShell'
 export { AppShellClient } from './AppShellClient'
-export { Sidebar } from './Sidebar'
-export type { SidebarProps } from './Sidebar'
+export { ProductSidebar } from './ProductSidebar'
+export type { ProductSidebarProps } from './ProductSidebar'
 export { TierBadge, tierLabel } from './TierBadge'
 export type { PlatformTier, TierBadgeProps } from './TierBadge'
 export { CreditsChip } from './CreditsChip'

--- a/src/hooks/use-viewport.ts
+++ b/src/hooks/use-viewport.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
 
 /**
- * TRC-14.8 — Largura mínima da aplicação autenticada (ADR-016).
+ * TRC-14.8 — Largura mínima da aplicação autenticada (ver Decision Log no
+ * Notion).
  *
  * Abaixo deste ponto, rotas do app devem exibir o banner `ViewportGate`.
  * Landing, onboarding, checkout, emails e status view seguem responsivos e

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,0 +1,25 @@
+/**
+ * TRC-14.9 — Single source of truth para rotas públicas do app.
+ *
+ * Consumido por `middleware.ts` (Clerk route matcher) e `AppShellClient.tsx`
+ * (filtro de rotas que não renderizam o shell global). Divergência entre os
+ * dois quebraria a expectativa: "rota pública não exige auth E não renderiza
+ * shell".
+ */
+
+// Pra filtro client-side do AppShellClient (startsWith). Mantém /.
+export const PUBLIC_ROUTE_PREFIXES = [
+  '/',
+  '/sign-in',
+  '/sign-up',
+  '/design-system',
+] as const
+
+// Pra createRouteMatcher do Clerk middleware (padrões com glob).
+export const MIDDLEWARE_PUBLIC_PATTERNS = [
+  '/',
+  '/sign-in(.*)',
+  '/sign-up(.*)',
+  '/design-system(.*)',
+  '/api/webhooks(.*)',
+] as const

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,15 +2,11 @@ import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 import { NextResponse } from 'next/server'
 import type { NextFetchEvent, NextRequest } from 'next/server'
 
-const isPublicRoute = createRouteMatcher([
-  '/',
-  '/sign-in(.*)',
-  '/sign-up(.*)',
-  '/api/webhooks(.*)',
-  // TRC-14.1 — pagina de referencia visual dos tokens do design system,
-  // exposta sem auth para inspecao em dev e validacao contra o mockup.
-  '/design-system(.*)',
-])
+import { MIDDLEWARE_PUBLIC_PATTERNS } from '@/lib/routes'
+
+// TRC-14.9 — padrões das rotas públicas centralizados em `src/lib/routes.ts`
+// pra manter em sincronia com o filtro client-side do `AppShellClient`.
+const isPublicRoute = createRouteMatcher([...MIDDLEWARE_PUBLIC_PATTERNS])
 
 const baseMiddleware = clerkMiddleware(async (auth, request) => {
   if (!isPublicRoute(request)) {

--- a/src/test/fixtures/maria-canonical.ts
+++ b/src/test/fixtures/maria-canonical.ts
@@ -22,8 +22,6 @@ import {
   ProjectPhase,
   ReviewCadence,
   RiskCategory,
-  RiskImpact,
-  RiskProbability,
 } from '@prisma/client'
 
 // ----------------------------------------------------------------------------
@@ -349,8 +347,6 @@ export interface MariaRiskDraft {
   description: string
   trigger: string
   category: RiskCategory
-  impact: RiskImpact
-  probability: RiskProbability
   origin: string
 }
 
@@ -363,8 +359,6 @@ export const MARIA_RISK_DRAFTS: MariaRiskDraft[] = [
     trigger:
       'Webhook do MP atrasar > 30s · resposta 4xx/5xx do endpoint /api/mp/webhook · diferença entre pedidos no painel e extrato MP do dia.',
     category: RiskCategory.TECNICO,
-    impact: RiskImpact.ALTO,
-    probability: RiskProbability.MEDIA,
     origin: 'Plano Técnico · Integrações',
   },
   {
@@ -378,8 +372,6 @@ export const MARIA_RISK_DRAFTS: MariaRiskDraft[] = [
     // não recebe), não disputa de mercado. Mockup original usava 'Operacional'
     // (inexistente no enum). Suggestion Code-Reviewer TRC-14.7.
     category: RiskCategory.REPUTACAO,
-    impact: RiskImpact.MEDIO,
-    probability: RiskProbability.ALTA,
     origin: 'Plano de UX · Telas principais',
   },
 ]


### PR DESCRIPTION
## Summary

Endereça as 7 dívidas técnicas identificadas no design review de TRC-14.4 + full codebase review pós-TRC-14. Fecha o épico TRC-14 Fundação.

Notion: [TRC-14 épico](https://www.notion.so/34b0d9578db3813e860ecacb4a83055e)

## Cleanup items

| # | Escopo | Arquivos | Mudança |
|---|---|---|---|
| 1 | html lang | `app/layout.tsx` | `en` → `pt-BR` |
| 2 | CreditsChip showcase text | `design-system/shell-showcase.tsx` | Thresholds corrigidos (≥13 / 7-12 / <7) |
| 3 | MariaRiskDraft interface | `test/fixtures/maria-canonical.ts` | Remove impact/probability (pertencem a Risk) |
| 4 | `userInitial` prop morta | AppShell, AppShellClient, ProductSidebar, UserChip | Removida em toda cadeia |
| 5 | Rename Sidebar | `shell/Sidebar.tsx` → `shell/ProductSidebar.tsx` | + type ProductSidebarProps; consumidores atualizados |
| 6 | Rotas públicas single source | `lib/routes.ts` (novo) | Middleware + AppShellClient consomem de um só lugar |
| 7 | Refs ADR numéricas ausentes | shell-showcase, AppShellClient, ViewportGate, use-viewport | Remove ADR-014/015/016, aponta pro Notion Decision Log |

## Verificação

- [x] `git grep userInitial` = 0 ocorrências
- [x] `git grep "ADR-01[456]"` em `src/` = 0 ocorrências
- [x] `git grep "from '@/components/shell/Sidebar'"` = 0 ocorrências (todos migrados pra ProductSidebar)
- [x] `npm run lint` limpo
- [x] `npm run build` passa
- [x] `npm test` — 597/597 passam

## Decisões fora do briefing

- `AppShellClient.isPublicPath`: mantido early-return `pathname === '/'` + filtro `'/'` no `.some(...)` pra não retornar true pra qualquer caminho (todos começam com `/`). Comportamento equivalente, mas consumindo a constante compartilhada.
- `as const` em `MIDDLEWARE_PUBLIC_PATTERNS` exige spread `[...MIDDLEWARE_PUBLIC_PATTERNS]` no middleware pra destravar o `readonly` contra a assinatura do `createRouteMatcher`.

## Test plan

- [x] 597/597 testes
- [ ] Abrir `/dashboard` em dev — sidebar nova renderiza idêntica (só rename interno)
- [ ] Abrir `/design-system` — showcase mostra thresholds corretos no texto
- [ ] Abrir DevTools → `document.documentElement.lang` = `"pt-BR"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)